### PR TITLE
feat: 닉네임 중복 확인 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/global/config/SecurityConfig.java
+++ b/src/main/java/com/yooyoung/clotheser/global/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)  // csrf, api server 이용 시 .disable (html tag를 통한 공격)
                 .cors(Customizer.withDefaults())	 //  다른 도메인의 리소스에 대해 접근이 허용되는지 체크
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/api/v1/users/signup", "/api/v1/users/login").permitAll() // 안에 작성된 경로의 api 요청은 인증 없이 모두 허용
+                        .requestMatchers("/api/v1/users/signup", "/api/v1/users/check-nickname/{nickname}", "/api/v1/users/login").permitAll() // 안에 작성된 경로의 api 요청은 인증 없이 모두 허용
                         .anyRequest().authenticated()   // 각 경로 path별 권한 처리
                 )
                 .sessionManagement((session) -> session     // 세션 관리 기능 작동 - .maximunSessions(숫자)로 최대 허용 가능 세션 수를 정할 수 있음 (-1로 하면 무제한 허용)

--- a/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
+++ b/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
@@ -51,6 +51,17 @@ public class UserController {
         }
     }
 
+    // 닉네임 중복 확인
+    @GetMapping("/check-nickname/{nickname}")
+    public ResponseEntity<BaseResponse<?>> checkNickname(@PathVariable String nickname) {
+        try {
+            return new ResponseEntity<>(new BaseResponse<>(userService.checkNickname(nickname)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
     // 최초 로그인
 
     // 이후 로그인

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -39,7 +39,7 @@ public class User {
 
     private String profileUrl;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 20)
     private String phoneNumber;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -63,9 +63,9 @@ public class User {
     private int rentalCount;
 
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
-    @ColumnDefault("false")     // DB 기본값 설정
+    @ColumnDefault("true")     // DB 기본값 설정
     @Builder.Default            // 객체 생성 시 기본값 설정
-    private Boolean isFirstLogin = false;
+    private Boolean isFirstLogin = true;
 
     // 관리자 계정은 DB에서 직접 변경
     @Column(nullable = false, columnDefinition = "TINYINT(1)")

--- a/src/main/java/com/yooyoung/clotheser/user/dto/SignUpResponseDto.java
+++ b/src/main/java/com/yooyoung/clotheser/user/dto/SignUpResponseDto.java
@@ -1,9 +1,11 @@
 package com.yooyoung.clotheser.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.yooyoung.clotheser.user.domain.User;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Setter(AccessLevel.NONE)
@@ -16,6 +18,9 @@ public class SignUpResponseDto {
     private LocalDate birthday;
     private String phoneNumber;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+
     public SignUpResponseDto(User user) {
         this.name = user.getName();
         this.nickname = user.getNickname();
@@ -23,6 +28,7 @@ public class SignUpResponseDto {
         this.password = user.getPassword();
         this.birthday = user.getBirthday();
         this.phoneNumber = user.getPhoneNumber();
+        this.createdAt = user.getCreatedAt();
     }
 
 }

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.yooyoung.clotheser.user.service;
 
 import com.yooyoung.clotheser.global.entity.BaseException;
+import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
 import com.yooyoung.clotheser.user.domain.User;
 import com.yooyoung.clotheser.user.dto.SignUpRequestDto;
 import com.yooyoung.clotheser.user.dto.SignUpResponseDto;
@@ -49,4 +50,12 @@ public class UserService {
         return new SignUpResponseDto(userRepository.save(user));
     }
 
+
+    // 닉네임 중복 확인
+    public BaseResponseStatus checkNickname(String nickname) throws BaseException {
+        if (userRepository.existsByNicknameAndDeletedAtNull(nickname)) {
+            throw new BaseException(NICKNAME_EXISTS, CONFLICT);
+        }
+        return SUCCESS;
+    }
 }


### PR DESCRIPTION
## 🎯 관련 이슈
close #9 

<br>

## 📝 구현 내용
- [x] 닉네임 중복 확인 API
- [x] 유저 엔티티 옵션 변경
    - [x] 전화번호 길이 제한
    - [x] is_first_login 기본값 변경
- [x] 회원가입 응답값에 createdAt 추가 (확인용)  

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
