### PR TITLE
feat: JWT를 이용한 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,26 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // SpringSecurity
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -35,6 +35,9 @@ public enum BaseResponseStatus {
     // 최초 로그인
     IS_NOT_FIRST_LOGIN(false, 2300, "최초 로그인이 아닙니다."),
 
+    // 로그인
+    LOGIN_MISMATCH(false, 2400, "이메일과 비밀번호가 일치하지 않습니다."),
+
 
     /*
         3000 : Response 오류

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -16,12 +16,12 @@ public enum BaseResponseStatus {
     */
     // 1. Common (2000 ~ 2099)
     REQUEST_ERROR(false, 2000, "입력값을 확인해주세요."),
-    EMPTY_JWT(false, 2001, "JWT 토큰을 입력해주세요."),
+    EMPTY_JWT(false, 2001, "JWT를 입력해주세요."),
     INVALID_USER_JWT(false, 2002, "권한이 없는 유저의 접근입니다."),
-    INVALID_JWT_TOKEN(false, 2003, "유효하지 않은 JWT 토큰입니다."),
-    EXPIRED_JWT_TOKEN(false, 2004, "만료된 JWT 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(false, 2005, "지원하지 않는 JWT 토큰입니다."),
-    EMPTY_JWT_CLAIMS(false, 2006, "JWT 토큰이 잘못되었습니다."),
+    INVALID_JWT_TOKEN(false, 2003, "유효하지 않은 JWT입니다."),
+    EXPIRED_JWT_TOKEN(false, 2004, "만료된 JWT입니다."),
+    UNSUPPORTED_JWT_TOKEN(false, 2005, "지원하지 않는 JWT입니다."),
+    EMPTY_JWT_CLAIMS(false, 2006, "JWT가 잘못되었습니다."),
 
     // 2. User (2100 ~ 2199)
     NOT_FOUND_USER(false, 2100, "회원을 찾을 수 없습니다."),

--- a/src/main/java/com/yooyoung/clotheser/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yooyoung/clotheser/global/jwt/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import com.yooyoung.clotheser.global.entity.*;
 import com.yooyoung.clotheser.user.domain.RefreshToken;
 import com.yooyoung.clotheser.user.dto.TokenResponse;
 import com.yooyoung.clotheser.user.repository.RefreshTokenRepository;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -61,14 +62,11 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                         throw new BaseException(EXPIRED_JWT_TOKEN, BAD_REQUEST);
                     }
                 }
-                // 4. Access 만료된 경우
-                else {
-                    throw new BaseException(EXPIRED_JWT_TOKEN, BAD_REQUEST);
-                }
             }
         }
         catch (BaseException e) {
             jwtExceptionHandler((HttpServletResponse) response, e.getStatus(), e.getHttpStatus());
+            return; // 예외가 발생하면 필터 체인을 중단
         }
         chain.doFilter(request, response);
     }
@@ -77,6 +75,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     public void jwtExceptionHandler(HttpServletResponse response, BaseResponseStatus status, HttpStatus httpStatus) {
         response.setStatus(httpStatus.value());
         response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
         try {
             String json = new ObjectMapper().writeValueAsString(new BaseResponse<>(status));
             response.getWriter().write(json);

--- a/src/main/java/com/yooyoung/clotheser/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yooyoung/clotheser/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,88 @@
+package com.yooyoung.clotheser.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yooyoung.clotheser.global.entity.*;
+import com.yooyoung.clotheser.user.domain.RefreshToken;
+import com.yooyoung.clotheser.user.dto.TokenResponse;
+import com.yooyoung.clotheser.user.repository.RefreshTokenRepository;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
+import static org.springframework.http.HttpStatus.*;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, java.io.IOException {
+        // Request Header에서 JWT 추출
+        String accessToken = jwtProvider.getHeaderToken((HttpServletRequest) request, "Authorization");
+        String refreshToken = jwtProvider.getHeaderToken((HttpServletRequest) request, "Authorization-refresh");
+
+        try {
+            if (accessToken != null) {
+                // 1. Access 유효한 경우
+                if (jwtProvider.validateToken(accessToken)) {
+                    accessToken = accessToken.split(" ")[1].trim();
+                    Authentication authentication = jwtProvider.getAuthentication(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+                else if (refreshToken != null) {
+                    boolean isRefreshToken = jwtProvider.validateRefreshToken(refreshToken);
+                    refreshToken = refreshToken.split(" ")[1].trim();
+                    // 2. Access 만료 & Refresh 유효
+                    if (isRefreshToken) {
+                        RefreshToken rt = refreshTokenRepository.findByToken(refreshToken)
+                                .orElseThrow(() -> new BaseException(INVALID_JWT_TOKEN, NOT_FOUND));
+
+                        Long userId = rt.getUserId();
+                        TokenResponse tokenResponse = jwtProvider.createToken(userId);
+                        String newAccessToken = tokenResponse.getAccessToken();
+
+                        jwtProvider.setHeaderAccessToken((HttpServletResponse) response, newAccessToken);
+
+                        Authentication authentication = jwtProvider.getAuthentication(newAccessToken);
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+                    // 3. Access, Refresh 둘 다 만료
+                    else {
+                        throw new BaseException(EXPIRED_JWT_TOKEN, BAD_REQUEST);
+                    }
+                }
+                // 4. Access 만료된 경우
+                else {
+                    throw new BaseException(EXPIRED_JWT_TOKEN, BAD_REQUEST);
+                }
+            }
+        }
+        catch (BaseException e) {
+            jwtExceptionHandler((HttpServletResponse) response, e.getStatus(), e.getHttpStatus());
+        }
+        chain.doFilter(request, response);
+    }
+
+    // JWT 관련 예외 처리
+    public void jwtExceptionHandler(HttpServletResponse response, BaseResponseStatus status, HttpStatus httpStatus) {
+        response.setStatus(httpStatus.value());
+        response.setContentType("application/json");
+        try {
+            String json = new ObjectMapper().writeValueAsString(new BaseResponse<>(status));
+            response.getWriter().write(json);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/global/jwt/JwtProvider.java
+++ b/src/main/java/com/yooyoung/clotheser/global/jwt/JwtProvider.java
@@ -1,0 +1,129 @@
+package com.yooyoung.clotheser.global.jwt;
+
+import com.yooyoung.clotheser.user.domain.RefreshToken;
+import com.yooyoung.clotheser.user.dto.TokenResponse;
+import com.yooyoung.clotheser.user.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    SecretKey key;
+
+    private final UserDetailsService userDetailsService;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @PostConstruct
+    protected void init() {
+        key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 토큰 생성
+    public TokenResponse createToken(Long userId) {
+        Claims claims = Jwts.claims().subject(String.valueOf(userId)).build();
+        long now = (new Date()).getTime();
+
+        // 토큰 유효 시간
+        long accessTokenExp = 60 * 60 * 24 * 1000L;     // 1일
+        long refreshTokenExp = accessTokenExp * 14;    // 2주 (14일)
+
+        String accessToken = Jwts.builder()
+                .claims(claims)
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + accessTokenExp))
+                .signWith(key)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + refreshTokenExp))
+                .signWith(key)
+                .compact();
+
+        return TokenResponse.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 헤더에서 토큰 받아오기
+    public String getHeaderToken(HttpServletRequest request, String type) {
+        return type.equals("Authorization") ? request.getHeader("Authorization") : request.getHeader("Authorization-refresh");
+    }
+
+    public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
+        response.setHeader("Authorization", accessToken);
+    }
+    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
+        response.setHeader("Authorization-refresh", refreshToken);
+    }
+
+    // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼냄 (권한 확인)
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserId(token).toString());
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    // 토큰으로부터 userId 획득
+    public Long getUserId(String token) {
+        return Long.parseLong(Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload().getSubject());
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        // Bearer 검증
+        if (token == null || !token.startsWith("Bearer ")) {
+            return false;
+        }
+        else {
+            token = token.substring(7); // "Bearer " 제거
+        }
+        Jws<Claims> claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+
+        // 토큰이 만료되어 있으면 false
+        return !claims.getPayload().getExpiration().before(new Date());
+    }
+
+    // Refresh Token 검증
+    public boolean validateRefreshToken(String token) {
+        if (!validateToken(token)) {
+            return false;
+        }
+
+        Optional<RefreshToken> refreshToken = refreshTokenRepository.findByToken(token);
+        return refreshToken.isPresent() && token.equals(refreshToken.get().getToken());
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/global/jwt/JwtProvider.java
+++ b/src/main/java/com/yooyoung/clotheser/global/jwt/JwtProvider.java
@@ -23,9 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.EXPIRED_JWT_TOKEN;
-import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.INVALID_JWT_TOKEN;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
+import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
+++ b/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
@@ -3,16 +3,14 @@ package com.yooyoung.clotheser.user.controller;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponse;
 import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
-import com.yooyoung.clotheser.user.dto.FirstLoginRequest;
-import com.yooyoung.clotheser.user.dto.FirstLoginResponse;
-import com.yooyoung.clotheser.user.dto.SignUpRequest;
-import com.yooyoung.clotheser.user.dto.SignUpResponse;
+import com.yooyoung.clotheser.user.dto.*;
 import com.yooyoung.clotheser.user.service.UserService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
@@ -65,6 +63,26 @@ public class UserController {
         }
     }
 
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest loginRequest,
+                                                             BindingResult bindingResult) {
+        try {
+            // 입력 유효성 검사
+            if (bindingResult.hasErrors()) {
+                List<FieldError> list = bindingResult.getFieldErrors();
+                for(FieldError error : list) {
+                    return new ResponseEntity<>(new BaseResponse<>(REQUEST_ERROR, error.getDefaultMessage()), BAD_REQUEST);
+                }
+            }
+
+            return new ResponseEntity<>(new BaseResponse<>(userService.login(loginRequest)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
     // TODO: 토큰 적용
     // 최초 로그인
     @PostMapping("/first-login")
@@ -85,8 +103,6 @@ public class UserController {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
         }
     }
-
-    // 로그인
 
     // 로그아웃
 

--- a/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
+++ b/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
@@ -10,7 +10,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
@@ -82,6 +81,18 @@ public class UserController {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
         }
     }
+
+    // TODO: 액세스 토큰 재발급
+    /*@PostMapping("/token/refresh")
+    public ResponseEntity<BaseResponse<TokenResponse>> refreshToken(@RequestHeader("Authorization") String refreshToken) {
+        try {
+
+            return new ResponseEntity<>(new BaseResponse<>(userService.refreshToken(refreshToken)), CREATED);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }*/
 
     // TODO: 토큰 적용
     // 최초 로그인

--- a/src/main/java/com/yooyoung/clotheser/user/domain/CustomUserDetails.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/CustomUserDetails.java
@@ -1,0 +1,51 @@
+package com.yooyoung.clotheser.user.domain;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    public final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/yooyoung/clotheser/user/domain/RefreshToken.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.yooyoung.clotheser.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(unique = true, nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 1000)
+    private String token;
+
+    public RefreshToken updateRefreshToken(String token) {
+        this.token = token;
+        return this;
+    }
+
+    public void destroyRefreshToken() {
+        this.token = null;
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -29,10 +29,10 @@ public class User {
     @Column(nullable = false, length = 20)
     private String name;
 
-    @Column(nullable = false, length = 20, unique = true)
+    @Column(nullable = false, length = 20)
     private String nickname;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)
@@ -40,7 +40,7 @@ public class User {
 
     private String profileUrl;
 
-    @Column(nullable = false, unique = true, length = 20)
+    @Column(nullable = false, length = 20)
     private String phoneNumber;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/com/yooyoung/clotheser/user/dto/LoginRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/user/dto/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.yooyoung.clotheser.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+}

--- a/src/main/java/com/yooyoung/clotheser/user/dto/LoginResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/user/dto/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.yooyoung.clotheser.user.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@AllArgsConstructor
+@Setter(AccessLevel.NONE)
+public class LoginResponse {
+
+    private String email;
+    private Boolean isFirstLogin;
+    private TokenResponse token;
+
+}

--- a/src/main/java/com/yooyoung/clotheser/user/dto/TokenResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/user/dto/TokenResponse.java
@@ -1,0 +1,13 @@
+package com.yooyoung.clotheser.user.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+public class TokenResponse {
+
+    private String grantType; // JWT에 대한 인증 타입 (Bearer)
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/yooyoung/clotheser/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package com.yooyoung.clotheser.user.repository;
+
+import com.yooyoung.clotheser.user.domain.RefreshToken;
+import com.yooyoung.clotheser.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    RefreshToken findByUserId(Long userId);
+
+}

--- a/src/main/java/com/yooyoung/clotheser/user/repository/UserRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/user/repository/UserRepository.java
@@ -17,4 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByIdAndDeletedAtNull(Long id);
 
+    Optional<User> findByEmailAndDeletedAtNull(String email);
 }

--- a/src/main/java/com/yooyoung/clotheser/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/CustomUserDetailService.java
@@ -1,0 +1,24 @@
+package com.yooyoung.clotheser.user.service;
+
+import com.yooyoung.clotheser.user.domain.CustomUserDetails;
+import com.yooyoung.clotheser.user.domain.User;
+import com.yooyoung.clotheser.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByIdAndDeletedAtNull(Long.parseLong(username))
+                .orElseThrow(() -> new UsernameNotFoundException("회원을 찾을 수 없습니다."));
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -2,21 +2,15 @@ package com.yooyoung.clotheser.user.service;
 
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
-import com.yooyoung.clotheser.user.domain.BodyShape;
-import com.yooyoung.clotheser.user.domain.FavClothes;
-import com.yooyoung.clotheser.user.domain.FavStyle;
-import com.yooyoung.clotheser.user.domain.User;
-import com.yooyoung.clotheser.user.dto.FirstLoginRequest;
-import com.yooyoung.clotheser.user.dto.FirstLoginResponse;
-import com.yooyoung.clotheser.user.dto.SignUpRequest;
-import com.yooyoung.clotheser.user.dto.SignUpResponse;
-import com.yooyoung.clotheser.user.repository.BodyShapeRepository;
-import com.yooyoung.clotheser.user.repository.FavClothesRepository;
-import com.yooyoung.clotheser.user.repository.FavStyleRepository;
-import com.yooyoung.clotheser.user.repository.UserRepository;
+import com.yooyoung.clotheser.global.jwt.JwtProvider;
+import com.yooyoung.clotheser.user.domain.*;
+import com.yooyoung.clotheser.user.dto.*;
+import com.yooyoung.clotheser.user.repository.*;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,21 +18,19 @@ import java.util.List;
 import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
 import static org.springframework.http.HttpStatus.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
-    /*
-        내가 설정한 EncrypterConfig 파일을 호출하여 사용해도 되지만,
-        Spring에서는 기존 BCryptPasswordEncoder 클래스를 DI 하겠다고 선언하면
-        알아서 해당 설정 Bean파일인 EncrypterConfig와 매칭시켜서 사용할 수 있게 해줌
-    */
-    private final BCryptPasswordEncoder encoder;
 
     private final UserRepository userRepository;
     private final BodyShapeRepository bodyShapeRepository;
     private final FavClothesRepository favClothesRepository;
     private final FavStyleRepository favStyleRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     // 회원가입
     public SignUpResponse signUp(SignUpRequest signUpRequest) throws BaseException {
@@ -58,7 +50,7 @@ public class UserService {
         }
 
         // 비밀번호 암호화
-        String encodedPassword = encoder.encode(signUpRequest.getPassword());
+        String encodedPassword = passwordEncoder.encode(signUpRequest.getPassword());
         User user = signUpRequest.toEntity(encodedPassword);
 
         return new SignUpResponse(userRepository.save(user));
@@ -70,6 +62,39 @@ public class UserService {
             throw new BaseException(NICKNAME_EXISTS, CONFLICT);
         }
         return SUCCESS;
+    }
+
+    // 로그인
+    public LoginResponse login(LoginRequest loginRequest) throws BaseException {
+
+        // 먼저 이메일로 회원 존재 확인
+        User user = userRepository.findByEmailAndDeletedAtNull(loginRequest.getEmail())
+                .orElseThrow(() -> new BaseException(NOT_FOUND_USER, NOT_FOUND));
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            throw new BaseException(LOGIN_MISMATCH, BAD_REQUEST);
+        }
+
+        // 토큰 생성
+        TokenResponse tokenResponse = jwtProvider.createToken(user.getId());
+
+        // DB에 Refresh Token 있는지 확인
+        RefreshToken preRefreshToken = refreshTokenRepository.findByUserId(user.getId());
+
+        // - 있으면 업데이트
+        if (preRefreshToken != null) {
+            refreshTokenRepository.save(preRefreshToken.updateRefreshToken(tokenResponse.getRefreshToken()));
+        }
+        // - 없으면 새로 저장
+        else {
+            RefreshToken newToken = RefreshToken.builder()
+                    .userId(user.getId())
+                    .token(tokenResponse.getRefreshToken())
+                    .build();
+            refreshTokenRepository.save(newToken);
+        }
+
+        return new LoginResponse(user.getEmail(), user.getIsFirstLogin(), tokenResponse);
     }
 
     // 최초 로그인

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -9,7 +9,6 @@ import com.yooyoung.clotheser.user.repository.*;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -96,6 +95,22 @@ public class UserService {
 
         return new LoginResponse(user.getEmail(), user.getIsFirstLogin(), tokenResponse);
     }
+
+    // TODO: 액세스 토큰 재발급
+    /*public TokenResponse refreshToken(String refreshToken) throws BaseException {
+
+        // refresh token이 만료되었거나 없는 경우
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new BaseException(INVALID_JWT_TOKEN, NOT_FOUND);
+        }
+
+        // DB에서 refresh token 가져오기
+        RefreshToken rt = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new BaseException(INVALID_JWT_TOKEN, NOT_FOUND));
+
+        Long userId = rt.getUserId();
+        return jwtProvider.createToken(userId);
+    }*/
 
     // 최초 로그인
     public FirstLoginResponse firstLogin(FirstLoginRequest firstLoginRequest) throws BaseException {


### PR DESCRIPTION
## 🎯 관련 이슈
close #3 

<br>

## 📝 구현 내용
- [x] 일반 로그인 API 구현
    - [x] access token(1일), refresh token(2주) 발급
    - [x] 헤더에 access token 넣고 API 테스트
    - [x] access token 만료 테스트 

<br>

## ⭐ 차후 일정
- [ ] refresh token으로 access token 재발급 API

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
