### PR TITLE
feat: 대여글 조회 API (#23)

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -26,7 +26,6 @@ public enum BaseResponseStatus {
 
 
     // 2. User (2100 ~ 2199)
-    NOT_FOUND_USER(false, 2100, "회원을 찾을 수 없습니다."),
 
     // 회원가입
     PASSWORD_CONFIRMATION_MISMATCH(false, 2110, "비밀번호가 일치하지 않습니다."),
@@ -48,9 +47,14 @@ public enum BaseResponseStatus {
     /*
         3000 : Response 오류
     */
-    // Common
+    // 1. Common
     RESPONSE_ERROR(false, 3000, "값을 불러오는데 실패하였습니다."),
 
+    // 2. User
+    NOT_FOUND_USER(false, 3100, "회원을 찾을 수 없습니다."),
+
+    // 3. Rental
+    NOT_FOUND_RENTAL(false, 3200, "대여글을 찾을 수 없습니다."),
 
     /*
         4000 : Database, Server 오류

--- a/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
@@ -7,6 +7,7 @@ import com.yooyoung.clotheser.rental.dto.RentalResponse;
 import com.yooyoung.clotheser.rental.service.RentalService;
 import com.yooyoung.clotheser.user.domain.CustomUserDetails;
 
+import com.yooyoung.clotheser.user.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -49,4 +50,16 @@ public class RentalController {
         }
     }
 
+    // 대여글 조회
+    @GetMapping("/{rentalId}")
+    public ResponseEntity<BaseResponse<RentalResponse>> getRental(@PathVariable Long rentalId,
+                                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            User user = userDetails.user;
+            return new ResponseEntity<>(new BaseResponse<>(rentalService.getRental(rentalId, user)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalPriceDto.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalPriceDto.java
@@ -16,4 +16,9 @@ public class RentalPriceDto {
     @PositiveOrZero(message = "가격은 0 또는 자연수여야 합니다.")
     private Integer price;
 
+    public RentalPriceDto(Integer days, Integer price) {
+        this.days = days;
+        this.price = price;
+    }
+
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
@@ -15,9 +15,12 @@ import java.util.List;
 @Setter(AccessLevel.NONE)
 public class RentalResponse {
 
+    private Long id;
+
     // 회원 정보
     private String profileUrl;
     private String nickname;
+    private Boolean isWriter;
 
     // TODO: 팔로우 기능
     private int followers = 0;
@@ -45,8 +48,11 @@ public class RentalResponse {
     private LocalDateTime updatedAt;
 
     public RentalResponse(User user, Rental rental, List<RentalPriceDto> prices) {
-        this.profileUrl = user.getProfileUrl();
-        this.nickname = user.getNickname();
+        this.id = rental.getId();
+
+        this.profileUrl = rental.getUser().getProfileUrl();
+        this.nickname = rental.getUser().getNickname();
+        this.isWriter = rental.getUser().getId().equals(user.getId());
 
         // TODO: 팔로우 기능
         this.followers = 8;

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalPriceRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalPriceRepository.java
@@ -4,7 +4,11 @@ import com.yooyoung.clotheser.rental.domain.RentalPrice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RentalPriceRepository extends JpaRepository<RentalPrice, Long> {
+
+    List<RentalPrice> findAllByRentalId(Long rentalId);
 
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalRepository.java
@@ -4,6 +4,11 @@ import com.yooyoung.clotheser.rental.domain.Rental;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RentalRepository extends JpaRepository<Rental, Long> {
+
+    Optional<Rental> findByIdAndDeletedAtNull(Long id);
+
 }


### PR DESCRIPTION
## 🎯 관련 이슈
close #23 

<br>

## 📝 구현 내용
- [x] 로그인한 회원이 대여글의 작성자인지 확인 가능
- [x] 응답값은 대여글 생성 API와 동일 (대여글 id 포함시킴)
- [x] fix: 응답값에서 로그인한 사용자가 아닌 대여글 작성자의 정보가 보이도록 수정

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
