### PR TITLE
채팅방 목록 조회 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
@@ -1,5 +1,6 @@
 package com.yooyoung.clotheser.chat.controller;
 
+import com.yooyoung.clotheser.chat.dto.ChatRoomListResponse;
 import com.yooyoung.clotheser.chat.dto.ChatRoomResponse;
 import com.yooyoung.clotheser.chat.service.ChatService;
 import com.yooyoung.clotheser.global.entity.BaseException;
@@ -10,7 +11,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static org.springframework.http.HttpStatus.CREATED;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +35,15 @@ public class ChatController {
     }
 
     // 채팅방 목록 조회
+    @GetMapping("/rooms")
+    public ResponseEntity<BaseResponse<List<ChatRoomListResponse>>> getChatRoomList(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            return new ResponseEntity<>(new BaseResponse<>(chatService.getChatRoomList(userDetails.user)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
 
     // 채팅방 조회 (채팅 내역)
 

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomListResponse.java
@@ -1,20 +1,36 @@
 package com.yooyoung.clotheser.chat.dto;
 
+import com.yooyoung.clotheser.chat.domain.ChatRoom;
+import com.yooyoung.clotheser.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Setter(AccessLevel.NONE)
-// 채팅방 목록
+/* 채팅방 목록 */
 public class ChatRoomListResponse {
 
     private Long id;
-    private String nickname;
-    private String profileImgUrl;
     private String recentMessage;
 
+    // 상대방 정보
+    private String nickname;
+    private String profileImgUrl;
+
+    // 대여글 정보
     private String rentalImgUrl;
     private String title;
+
+    public ChatRoomListResponse(ChatRoom chatRoom, String recentMessage, String rentalImgUrl, User opponent) {
+        this.id = chatRoom.getId();
+        this.recentMessage = recentMessage;
+
+        this.nickname = opponent.getNickname();
+        this.profileImgUrl = opponent.getProfileUrl();
+
+        this.rentalImgUrl = rentalImgUrl;
+        this.title = chatRoom.getRental().getTitle();
+    }
 
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/repository/ChatMessageRepository.java
@@ -4,6 +4,11 @@ import com.yooyoung.clotheser.chat.domain.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    Optional<ChatMessage> findFirstByRoomIdOrderByCreatedAtDesc(Long roomId);
+
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/repository/ChatRoomRepository.java
@@ -2,11 +2,18 @@ package com.yooyoung.clotheser.chat.repository;
 
 import com.yooyoung.clotheser.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     boolean existsChatRoomByBuyerIdAndRentalId(Long buyerId, Long rentalId);
+
+    // TODO: updatedAt이 null 아닌 채팅방들만 보여주기 (null이면 채팅 메시지 없는 채팅방)
+    @Query("select c from ChatRoom c where c.buyer.id = :userId or c.lender.id = :userId order by c.updatedAt desc")
+    List<ChatRoom> findAllByUserId(Long userId);
 
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
@@ -2,25 +2,31 @@ package com.yooyoung.clotheser.chat.service;
 
 import com.yooyoung.clotheser.chat.domain.ChatMessage;
 import com.yooyoung.clotheser.chat.domain.ChatRoom;
+import com.yooyoung.clotheser.chat.dto.ChatRoomListResponse;
 import com.yooyoung.clotheser.chat.dto.ChatRoomResponse;
 import com.yooyoung.clotheser.chat.repository.ChatMessageRepository;
 import com.yooyoung.clotheser.chat.repository.ChatRoomRepository;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.rental.domain.Rental;
 import com.yooyoung.clotheser.rental.domain.RentalImg;
+import com.yooyoung.clotheser.rental.dto.RentalListReponse;
 import com.yooyoung.clotheser.rental.repository.RentalImgRepository;
 import com.yooyoung.clotheser.rental.repository.RentalPriceRepository;
 import com.yooyoung.clotheser.rental.repository.RentalRepository;
 import com.yooyoung.clotheser.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
 import static org.springframework.http.HttpStatus.*;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ChatService {
 
@@ -62,7 +68,7 @@ public class ChatService {
         chatRoomRepository.save(chatRoom);
 
         // 첫 번째 이미지 불러오기
-        Optional<RentalImg> optionalImg = rentalImgRepository.findOneByRentalId(rental.getId());
+        Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(rental.getId());
         String rentalImgUrl = optionalImg.map(RentalImg::getImgUrl).orElse(null);
 
         // 가격 정보 중에 제일 싼 가격 불러오기
@@ -71,6 +77,40 @@ public class ChatService {
 
         return new ChatRoomResponse(chatRoom, chatRoom.getLender().getNickname(), rental, rentalImgUrl, minPrice);
 
+    }
+
+    // TODO: 채팅 메시지 저장 로직 개발 후, 최근 메시지순으로 보여주는지 테스트 필요
+    // 채팅방 목록 조회
+    public List<ChatRoomListResponse> getChatRoomList(User user) throws BaseException {
+        // 최초 로그인이 아닌지 확인
+        if (user.getIsFirstLogin()) {
+            throw new BaseException(REQUEST_FIRST_LOGIN, FORBIDDEN);
+        }
+
+        List<ChatRoom> chatRoomList = chatRoomRepository.findAllByUserId(user.getId());
+        List<ChatRoomListResponse> chatRoomResponseList = new ArrayList<>();
+        for (ChatRoom chatRoom : chatRoomList) {
+
+            // 로그인한 회원이 대여자인지 판매자인지 구분
+            User opponent;
+            if (chatRoom.getBuyer().getId().equals(user.getId())) {
+                opponent = chatRoom.getLender();
+            }
+            else {
+                opponent = chatRoom.getBuyer();
+            }
+
+            // 채팅방의 최근 메시지 불러오기
+            Optional<ChatMessage> optionalMessage = chatMessageRepository.findFirstByRoomIdOrderByCreatedAtDesc(chatRoom.getId());
+            String recentMessage = optionalMessage.map(ChatMessage::getMessage).orElse(null);
+
+            // 대여글의 첫 번째 이미지 불러오기
+            Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(chatRoom.getRental().getId());
+            String imgUrl = optionalImg.map(RentalImg::getImgUrl).orElse(null);
+
+            chatRoomResponseList.add(new ChatRoomListResponse(chatRoom, recentMessage, imgUrl, opponent));
+        }
+        return chatRoomResponseList;
     }
 
     // 채팅 메시지 저장

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalImgRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalImgRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 @Repository
 public interface RentalImgRepository extends JpaRepository<RentalImg, Long> {
 
-    Optional<RentalImg> findOneByRentalId(Long rentalId);
+    Optional<RentalImg> findFirstByRentalId(Long rentalId);
 
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
@@ -14,6 +14,7 @@ import com.yooyoung.clotheser.rental.repository.RentalRepository;
 import com.yooyoung.clotheser.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,7 @@ import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
 import static org.springframework.http.HttpStatus.*;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class RentalService {
 
@@ -97,7 +99,7 @@ public class RentalService {
         List<RentalListReponse> responses = new ArrayList<>();
         for (Rental rental : rentalList) {
             // 첫 번째 이미지 불러오기
-            Optional<RentalImg> optionalImg = rentalImgRepository.findOneByRentalId(rental.getId());
+            Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(rental.getId());
             String imgUrl = optionalImg.map(RentalImg::getImgUrl).orElse(null);
 
             // 가격 정보 중에 제일 싼 가격 불러오기

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -8,9 +8,9 @@ import com.yooyoung.clotheser.user.dto.*;
 import com.yooyoung.clotheser.user.repository.*;
 import lombok.RequiredArgsConstructor;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,8 +19,8 @@ import java.util.stream.Collectors;
 import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
 import static org.springframework.http.HttpStatus.*;
 
-@Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class UserService {
 


### PR DESCRIPTION
## 🎯 관련 이슈
close #35 

<br>

## 📝 구현 내용
- [x] 채팅방 목록 조회 API (최근 메시지 보낸 순)
- [x] 모든 서비스 단에 Transactional 어노테이션 추가

<br>

## 💪 추후 작업 목록
- [ ] 채팅 메시지 저장 개발 후, 최근 메시지 보낸 순으로 보이는지 테스트
- [ ] 채팅 메시지가 없는 채팅방은 목록에서 보이지 않게 수정 (updatedAt이 null이 아닌 채팅방만 보이도록)

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
