### PR TITLE
채팅방 조회 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
@@ -45,7 +45,7 @@ public class ChatController {
         }
     }
 
-    /* 채팅방 조회 (채팅방 대화 내역) */
+    /* 채팅방 조회 (채팅 메시지 목록 포함) */
     @GetMapping("/rooms/{roomId}")
     public ResponseEntity<BaseResponse<ChatRoomResponse>> getChatMessageList(@PathVariable("roomId") Long roomId,
                                                                              @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
@@ -22,7 +22,7 @@ public class ChatController {
 
     private final ChatService chatService;
 
-    // 채팅방 생성
+    /* 채팅방 생성 */
     @PostMapping("/rooms/{rentalId}")
     public ResponseEntity<BaseResponse<ChatRoomResponse>> createChatRoom(@PathVariable("rentalId") Long rentalId,
                                                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -34,7 +34,7 @@ public class ChatController {
         }
     }
 
-    // 채팅방 목록 조회
+    /* 채팅방 목록 조회 */
     @GetMapping("/rooms")
     public ResponseEntity<BaseResponse<List<ChatRoomListResponse>>> getChatRoomList(@AuthenticationPrincipal CustomUserDetails userDetails) {
         try {
@@ -45,7 +45,17 @@ public class ChatController {
         }
     }
 
-    // 채팅방 조회 (채팅 내역)
+    /* 채팅방 조회 (채팅방 대화 내역) */
+    @GetMapping("/rooms/{roomId}")
+    public ResponseEntity<BaseResponse<ChatRoomResponse>> getChatMessageList(@PathVariable("roomId") Long roomId,
+                                                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            return new ResponseEntity<>(new BaseResponse<>(chatService.getChatRoom(roomId, userDetails.user)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
 
     // 옷 상태 체크하기
 

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
@@ -25,15 +25,16 @@ public class ChatRoomResponse {
     private Long rentalId;
     private String rentalImgUrl;
     private String title;
-    private int minPrice;
+    private Integer minPrice;
 
     private RentalState rentalState;
 
     // 채팅 메시지 목록
     private List<ChatMessageResponse> messages;
 
+    /* 채팅방 생성 시 쓰는 생성자 */
     public ChatRoomResponse(ChatRoom chatRoom, String opponentNickname,
-                            Rental rental, String rentalImgUrl, int minPrice) {
+                            Rental rental, String rentalImgUrl, Integer minPrice) {
         this.id = chatRoom.getId();
         this.buyerId = chatRoom.getBuyer().getId();
         this.lenderId = chatRoom.getLender().getId();
@@ -44,6 +45,24 @@ public class ChatRoomResponse {
         this.rentalImgUrl = rentalImgUrl;
         this.title = rental.getTitle();
         this.minPrice = minPrice;
+    }
+
+    /* 채팅방 조회 시 쓰는 생성자 */
+    public ChatRoomResponse(ChatRoom chatRoom, String opponentNickname, List<ChatMessageResponse> messages,
+                            String rentalImgUrl, Integer minPrice, RentalState rentalState) {
+        this.id = chatRoom.getId();
+        this.buyerId = chatRoom.getBuyer().getId();
+        this.lenderId = chatRoom.getLender().getId();
+
+        this.opponentNickname = opponentNickname;
+
+        this.rentalId = chatRoom.getRental().getId();
+        this.rentalImgUrl = rentalImgUrl;
+        this.title = chatRoom.getRental().getTitle();
+        this.minPrice = minPrice;
+
+        this.rentalState = rentalState;
+        this.messages = messages;
     }
 
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
@@ -16,8 +16,6 @@ import java.util.List;
 public class ChatRoomResponse {
 
     private Long id;
-    private Long buyerId;
-    private Long lenderId;
 
     private String opponentNickname;
 
@@ -36,8 +34,6 @@ public class ChatRoomResponse {
     public ChatRoomResponse(ChatRoom chatRoom, String opponentNickname,
                             Rental rental, String rentalImgUrl, Integer minPrice) {
         this.id = chatRoom.getId();
-        this.buyerId = chatRoom.getBuyer().getId();
-        this.lenderId = chatRoom.getLender().getId();
 
         this.opponentNickname = opponentNickname;
 
@@ -51,8 +47,6 @@ public class ChatRoomResponse {
     public ChatRoomResponse(ChatRoom chatRoom, String opponentNickname, List<ChatMessageResponse> messages,
                             String rentalImgUrl, Integer minPrice, RentalState rentalState) {
         this.id = chatRoom.getId();
-        this.buyerId = chatRoom.getBuyer().getId();
-        this.lenderId = chatRoom.getLender().getId();
 
         this.opponentNickname = opponentNickname;
 

--- a/src/main/java/com/yooyoung/clotheser/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/repository/ChatMessageRepository.java
@@ -4,6 +4,7 @@ import com.yooyoung.clotheser.chat.domain.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +12,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     Optional<ChatMessage> findFirstByRoomIdOrderByCreatedAtDesc(Long roomId);
 
+    List<ChatMessage> findByRoomId(Long roomId);
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/repository/ChatMessageRepository.java
@@ -12,5 +12,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     Optional<ChatMessage> findFirstByRoomIdOrderByCreatedAtDesc(Long roomId);
 
-    List<ChatMessage> findByRoomId(Long roomId);
+    List<ChatMessage> findAllByRoomId(Long roomId);
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
@@ -144,7 +144,7 @@ public class ChatService {
         return new ChatMessageResponse(chatMessageRepository.save(chatMessage));
     }
 
-    /* 채팅 메시지 목록 조회 (채팅방 대화 내역) */
+    /* 채팅방 조회 (채팅 메시지 목록 포함) */
     public ChatRoomResponse getChatRoom(Long roomId, User user) throws BaseException {
 
         // 최초 로그인이 아닌지 확인

--- a/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
@@ -162,7 +162,7 @@ public class ChatService {
         }
 
         // 대화 내역 불러오기
-        List<ChatMessage> chatMessageList = chatMessageRepository.findByRoomId(roomId);
+        List<ChatMessage> chatMessageList = chatMessageRepository.findAllByRoomId(roomId);
         List<ChatMessageResponse> chatMessageResponseList = new ArrayList<>();
         for (ChatMessage chatMessage : chatMessageList) {
             chatMessageResponseList.add(new ChatMessageResponse(chatMessage));

--- a/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
@@ -13,11 +13,14 @@ import com.yooyoung.clotheser.global.entity.BaseException;
 
 import com.yooyoung.clotheser.rental.domain.Rental;
 import com.yooyoung.clotheser.rental.domain.RentalImg;
+import com.yooyoung.clotheser.rental.domain.RentalInfo;
+import com.yooyoung.clotheser.rental.domain.RentalState;
 import com.yooyoung.clotheser.rental.repository.RentalImgRepository;
+import com.yooyoung.clotheser.rental.repository.RentalInfoRepository;
 import com.yooyoung.clotheser.rental.repository.RentalPriceRepository;
 import com.yooyoung.clotheser.rental.repository.RentalRepository;
 import com.yooyoung.clotheser.user.domain.User;
-import com.yooyoung.clotheser.user.repository.UserRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,9 +43,9 @@ public class ChatService {
     private final RentalRepository rentalRepository;
     private final RentalImgRepository rentalImgRepository;
     private final RentalPriceRepository rentalPriceRepository;
-    private final UserRepository userRepository;
+    private final RentalInfoRepository rentalInfoRepository;
 
-    // 채팅방 생성
+    /* 채팅방 생성 */
     public ChatRoomResponse createChatRoom(Long rentalId, User user) throws BaseException {
 
         // 최초 로그인이 아닌지 확인
@@ -77,15 +80,15 @@ public class ChatService {
         String rentalImgUrl = optionalImg.map(RentalImg::getImgUrl).orElse(null);
 
         // 가격 정보 중에 제일 싼 가격 불러오기
-        Optional<Integer> optionalPrice = rentalPriceRepository.findMinPrice(rental);
-        int minPrice = optionalPrice.orElse(0);
+        Integer minPrice = rentalPriceRepository.findMinPrice(rental).orElse(null);
 
         return new ChatRoomResponse(chatRoom, chatRoom.getLender().getNickname(), rental, rentalImgUrl, minPrice);
 
     }
 
-    // 채팅방 목록 조회
+    /* 채팅방 목록 조회 */
     public List<ChatRoomListResponse> getChatRoomList(User user) throws BaseException {
+
         // 최초 로그인이 아닌지 확인
         if (user.getIsFirstLogin()) {
             throw new BaseException(REQUEST_FIRST_LOGIN, FORBIDDEN);
@@ -117,7 +120,7 @@ public class ChatService {
         return chatRoomResponseList;
     }
 
-    // 채팅 메시지 생성 후 DB에 저장
+    /* 채팅 메시지 생성 후 DB에 저장 */
     public ChatMessageResponse createChatMessage(ChatMessageRequest chatMessageRequest, Long roomId, User user) throws BaseException {
 
         // 최초 로그인이 아닌지 확인
@@ -129,7 +132,7 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_CHAT_ROOM, NOT_FOUND));
 
-        // 채팅방 유저인지 확인
+        // 채팅방 참여자인지 확인
         if (!chatRoom.getBuyer().getId().equals(user.getId()) && !chatRoom.getLender().getId().equals(user.getId()) ) {
             throw new BaseException(FORBIDDEN_ENTER_CHAT_ROOM, FORBIDDEN);
         }
@@ -141,4 +144,56 @@ public class ChatService {
         return new ChatMessageResponse(chatMessageRepository.save(chatMessage));
     }
 
+    /* 채팅 메시지 목록 조회 (채팅방 대화 내역) */
+    public ChatRoomResponse getChatRoom(Long roomId, User user) throws BaseException {
+
+        // 최초 로그인이 아닌지 확인
+        if (user.getIsFirstLogin()) {
+            throw new BaseException(REQUEST_FIRST_LOGIN, FORBIDDEN);
+        }
+
+        // 채팅방 존재 확인
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_CHAT_ROOM, NOT_FOUND));
+
+        // 채팅방 참여자인지 확인
+        if (!chatRoom.getBuyer().getId().equals(user.getId()) && !chatRoom.getLender().getId().equals(user.getId()) ) {
+            throw new BaseException(FORBIDDEN_ENTER_CHAT_ROOM, FORBIDDEN);
+        }
+
+        // 대화 내역 불러오기
+        List<ChatMessage> chatMessageList = chatMessageRepository.findByRoomId(roomId);
+        List<ChatMessageResponse> chatMessageResponseList = new ArrayList<>();
+        for (ChatMessage chatMessage : chatMessageList) {
+            chatMessageResponseList.add(new ChatMessageResponse(chatMessage));
+        }
+
+        // 로그인한 회원이 대여자인지 판매자인지 구분
+        User opponent;
+        if (chatRoom.getBuyer().getId().equals(user.getId())) {
+            opponent = chatRoom.getLender();
+        }
+        else {
+            opponent = chatRoom.getBuyer();
+        }
+
+        // 유저 기반 채팅방인지 확인
+        if (chatRoom.getRental() == null) {
+            return new ChatRoomResponse(chatRoom, opponent.getNickname(), chatMessageResponseList, null, null, null);
+        }
+
+        // 첫 번째 이미지 불러오기
+        Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(chatRoom.getRental().getId());
+        String rentalImgUrl = optionalImg.map(RentalImg::getImgUrl).orElse(null);
+
+        // 가격 정보 중에 제일 싼 가격 불러오기
+        Integer minPrice = rentalPriceRepository.findMinPrice(chatRoom.getRental()).orElse(null);
+
+        // 대여 상태 불러오기
+        RentalInfo rentalInfo = rentalInfoRepository.findByRentalId(chatRoom.getRental().getId()).orElse(null);
+        RentalState rentalState = rentalInfo == null ? null : rentalInfo.getState();
+
+        return new ChatRoomResponse(chatRoom, opponent.getNickname(), chatMessageResponseList, rentalImgUrl, minPrice, rentalState);
+
+    }
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
@@ -1,0 +1,12 @@
+package com.yooyoung.clotheser.rental.repository;
+
+import com.yooyoung.clotheser.rental.domain.RentalInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RentalInfoRepository extends JpaRepository<RentalInfo, Long> {
+
+    Optional<RentalInfo> findByRentalId(Long rentalId);
+
+}


### PR DESCRIPTION
## 🎯 관련 이슈
close #39 

<br>

## 📝 구현 내용
- [x] 채팅방 조회 API
   - [x] 응답값에 채팅 메시지 목록 포함
   - [x] 응답값에서 대여자&판매자 id 삭제 (보안상)
   - [x] 응답값에 대여 상태값 포함
   - [x] 대여글 채팅방 & 유저 채팅방 응답값 다르게 설정 (ex. minPrice도 null일 수 있게 Integer로 변경)

<br>

## 💪 추후에 필요한 작업
- [ ] 대여하기&반납하기 후 채팅방 조회 시 대여 상태값 변경되는지 확인 필요

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
