### PR TITLE
대여글 생성 시 이미지 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/yooyoung/clotheser/global/config/S3Config.java
+++ b/src/main/java/com/yooyoung/clotheser/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.yooyoung.clotheser.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -23,6 +23,7 @@ public enum BaseResponseStatus {
     UNSUPPORTED_JWT_TOKEN(false, 2005, "지원하지 않는 JWT입니다."),
     EMPTY_JWT_CLAIMS(false, 2006, "JWT가 잘못되었습니다."),
     REQUEST_FIRST_LOGIN(false, 2007, "최초 로그인이 필요합니다."),
+    FILE_TOO_LARGE(false, 2008, "업로드 할 수 있는 최대 총 파일의 크기는 50MB입니다."),
 
 
     // 2. User (2100 ~ 2199)
@@ -44,6 +45,7 @@ public enum BaseResponseStatus {
     EMPTY_CLOTHES_ID(false, 2200, "보유 옷 id가 필요합니다."),
     FORBIDDEN_CREATE_RENTAL_INFO(false, 2201, "판매자만 대여 정보를 입력할 수 있습니다."),
     FORBIDDEN_UPDATE_RENTAL_INFO(false, 2202, "판매자만 대여 정보를 수정할 수 있습니다."),
+    TOO_MANY_IMAGES(false, 2203, "대여글 이미지는 최대 3장까지 첨부할 수 있습니다."),
 
     // 4. Chat (2300 ~ 2399)
     FORBIDDEN_CREATE_CHAT_ROOM(false, 2300, "대여글 작성자는 채팅방을 만들 수 없습니다."),
@@ -73,7 +75,8 @@ public enum BaseResponseStatus {
     */
     // Common
     DATABASE_ERROR(false, 4000, "데이터베이스 연결에 실패하였습니다."),
-    SERVER_ERROR(false, 4001, "서버와의 연결에 실패하였습니다.");
+    SERVER_ERROR(false, 4001, "서버와의 연결에 실패하였습니다."),
+    S3_UPLOAD_ERROR(false, 4002, "S3 이미지 업로드에 실패하였습니다.");
 
 
     private final boolean isSuccess;

--- a/src/main/java/com/yooyoung/clotheser/global/util/GlobalExceptionHandler.java
+++ b/src/main/java/com/yooyoung/clotheser/global/util/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.yooyoung.clotheser.global.util;
+
+import com.yooyoung.clotheser.global.entity.BaseResponse;
+import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
+import static org.springframework.http.HttpStatus.*;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 총 파일 크기 50MB 제한
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<BaseResponse<BaseResponseStatus>> handleMaxSizeException(MaxUploadSizeExceededException exc) {
+        return new ResponseEntity<>(new BaseResponse<>(FILE_TOO_LARGE), PAYLOAD_TOO_LARGE);
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -28,10 +29,10 @@ public class RentalController {
     private final RentalService rentalService;
 
     // 대여글 생성
-    @PostMapping("/{clothesId}")
-    public ResponseEntity<BaseResponse<RentalResponse>> createRentalPost(@Valid @RequestBody RentalRequest rentalRequest,
+    @PostMapping("")
+    public ResponseEntity<BaseResponse<RentalResponse>> createRentalPost(@Valid @RequestPart("post") RentalRequest rentalRequest,
                                                                          BindingResult bindingResult,
-                                                                         @PathVariable Long clothesId,
+                                                                         @RequestPart(value = "images", required = false) MultipartFile[] images,
                                                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
         try {
             // 입력 유효성 검사
@@ -42,7 +43,12 @@ public class RentalController {
                 }
             }
 
-            return new ResponseEntity<>(new BaseResponse<>(rentalService.createRentalPost(rentalRequest, clothesId, userDetails.user)), CREATED);
+            // 대여글 이미지 최대 3장
+            if (images.length > 3) {
+                throw new BaseException(TOO_MANY_IMAGES, PAYLOAD_TOO_LARGE);
+            }
+
+            return new ResponseEntity<>(new BaseResponse<>(rentalService.createRentalPost(rentalRequest, images, userDetails.user)), CREATED);
         }
         catch (BaseException exception) {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalRequest.java
@@ -17,8 +17,6 @@ import java.util.List;
 @Builder
 public class RentalRequest {
 
-    private List<String> imgUrls;
-
     @NotBlank(message = "제목을 입력해주세요.")
     @Size(max = 20, message = "제목은 20자 이내로 입력해주세요.")
     private String title;
@@ -39,10 +37,9 @@ public class RentalRequest {
     private String size;
     private String fit;
 
-    public Rental toEntity(User user, Long clothesId) {
+    public Rental toEntity(User user) {
         return Rental.builder()
                 .user(user)
-                .clothesId(clothesId)
                 .title(title)
                 .description(description)
                 .gender(gender)

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
@@ -47,7 +47,7 @@ public class RentalResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime updatedAt;
 
-    public RentalResponse(User user, Rental rental, List<RentalPriceDto> prices) {
+    public RentalResponse(User user, Rental rental, List<String> imgUrls, List<RentalPriceDto> prices) {
         this.id = rental.getId();
 
         this.profileUrl = rental.getUser().getProfileUrl();
@@ -57,6 +57,8 @@ public class RentalResponse {
         // TODO: 팔로우 기능
         this.followers = 8;
         this.followees = 5;
+
+        this.imgUrls = imgUrls;
 
         this.title = rental.getTitle();
         this.description = rental.getDescription();

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalImgRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalImgRepository.java
@@ -4,11 +4,16 @@ import com.yooyoung.clotheser.rental.domain.RentalImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RentalImgRepository extends JpaRepository<RentalImg, Long> {
 
+    // 대여글의 모든 이미지들 가져오기
+    List<RentalImg> findByRentalId(Long rentalId);
+
+    // 대여글 첫 번째 이미지 가져오기
     Optional<RentalImg> findFirstByRentalId(Long rentalId);
 
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/service/S3Service.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/S3Service.java
@@ -1,0 +1,70 @@
+package com.yooyoung.clotheser.rental.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.yooyoung.clotheser.global.entity.BaseException;
+import com.yooyoung.clotheser.rental.domain.Rental;
+import com.yooyoung.clotheser.rental.domain.RentalImg;
+import com.yooyoung.clotheser.rental.repository.RentalImgRepository;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
+import static org.springframework.http.HttpStatus.*;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final RentalImgRepository rentalImgRepository;
+
+    public List<String> uploadImages(MultipartFile[] images, Rental rental) throws BaseException {
+        List<String> imgUrls = new ArrayList<>();
+
+        // 대여글 이미지 없는 경우
+        if (images[0].isEmpty()) {
+            return null;
+        }
+
+        try {
+            for (MultipartFile image : images) {
+                // 파일명 중복 방지 위해 랜덤 숫자 추가
+                String fileName = "rentals/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
+
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(image.getSize());
+                metadata.setContentType(image.getContentType());
+
+                amazonS3.putObject(bucket, fileName, image.getInputStream(), metadata);
+                String imgUrl = amazonS3.getUrl(bucket, fileName).toString();
+                imgUrls.add(imgUrl);
+
+                // 데이터베이스에 이미지 URL 저장
+                RentalImg rentalImg = RentalImg.builder()
+                        .imgUrl(imgUrl)
+                        .rental(rental)
+                        .build();
+
+                rentalImgRepository.save(rentalImg);
+            }
+        } catch (IOException e) {
+            throw new BaseException(S3_UPLOAD_ERROR, INTERNAL_SERVER_ERROR);
+        }
+
+        return imgUrls;
+    }
+}
+


### PR DESCRIPTION
## 🎯 관련 이슈
close #46 

<br>

## 📝 구현 내용
- [x] S3 세팅 및 설정
- [x] multipart/form-data로 대여글 정보&이미지 함께 받음
- [x] 이미지 입력 선택 사항, 최대 3장으로 제한
- [x] 총 파일 크기 50MB 제한 (요청은 100MB)
- [x] 대여글 조회 시 S3 URL 보여주기

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
