### PR TITLE
API별 응답값 변경

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/controller/ChatController.java
@@ -5,6 +5,7 @@ import com.yooyoung.clotheser.chat.dto.ChatRoomResponse;
 import com.yooyoung.clotheser.chat.service.ChatService;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponse;
+import com.yooyoung.clotheser.global.entity.ChatRoomException;
 import com.yooyoung.clotheser.user.domain.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,10 @@ public class ChatController {
                                                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
         try {
             return new ResponseEntity<>(new BaseResponse<>(chatService.createChatRoom(rentalId, userDetails.user)), CREATED);
+        }
+        catch (ChatRoomException exception) {
+            // 채팅방 이미 존재 시 응답값에 기존 채팅방 id 포함
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus(), exception.getRoomId()), exception.getHttpStatus());
         }
         catch (BaseException exception) {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomListResponse.java
@@ -2,13 +2,15 @@ package com.yooyoung.clotheser.chat.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.yooyoung.clotheser.chat.domain.ChatRoom;
+import com.yooyoung.clotheser.global.entity.Time;
+import com.yooyoung.clotheser.rental.domain.RentalInfo;
 import com.yooyoung.clotheser.rental.domain.RentalState;
 import com.yooyoung.clotheser.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Data
 @Setter(AccessLevel.NONE)
@@ -28,13 +30,20 @@ public class ChatRoomListResponse {
     // 대여 상태
     private RentalState rentalState;
 
+    // 대여 시작일 & 반납 예정일
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+    private LocalDate startDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+    private LocalDate endDate;
+
     // 최근 메시지
     private String recentMessage;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime recentMessageTime;
+    private String recentMessageTime;
 
 
-    public ChatRoomListResponse(ChatRoom chatRoom, RentalState rentalState, String recentMessage, String rentalImgUrl, User opponent) {
+    public ChatRoomListResponse(ChatRoom chatRoom, RentalInfo rentalInfo, String recentMessage, String rentalImgUrl, User opponent) {
         this.id = chatRoom.getId();
 
         this.nickname = opponent.getNickname();
@@ -43,10 +52,14 @@ public class ChatRoomListResponse {
         this.title = chatRoom.getRental().getTitle();
         this.rentalImgUrl = rentalImgUrl;
 
-        this.rentalState = rentalState;
+        if (rentalInfo != null) {
+            this.rentalState = rentalInfo.getState();
+            this.startDate = rentalInfo.getStartDate();
+            this.endDate = rentalInfo.getEndDate();
+        }
 
         this.recentMessage = recentMessage;
-        this.recentMessageTime = chatRoom.getUpdatedAt();
+        this.recentMessageTime = Time.calculateTime(chatRoom.getUpdatedAt());
 
 
     }

--- a/src/main/java/com/yooyoung/clotheser/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/repository/ChatRoomRepository.java
@@ -6,11 +6,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    boolean existsChatRoomByBuyerIdAndRentalId(Long buyerId, Long rentalId);
+    // 기존 채팅방 확인
+    Optional<ChatRoom> findOneByBuyerIdAndRentalId(Long buyerId, Long rentalId);
 
     // updatedAt이 null이 아닌 채팅방들만 보여주기 (null이면 채팅 메시지 없는 채팅방)
     @Query("select c from ChatRoom c where (c.buyer.id = :userId or c.lender.id = :userId) and c.updatedAt is not null order by c.updatedAt desc")

--- a/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/ChatService.java
@@ -112,7 +112,6 @@ public class ChatService {
                     chatRoom.getBuyer().getId(),
                     chatRoom.getLender().getId(),
                     chatRoom.getRental().getId()).orElse(null);
-            RentalState rentalState = rentalInfo == null ? null : rentalInfo.getState();
 
             // 채팅방의 최근 메시지 불러오기
             Optional<ChatMessage> optionalMessage = chatMessageRepository.findFirstByRoomIdOrderByCreatedAtDesc(chatRoom.getId());
@@ -122,7 +121,7 @@ public class ChatService {
             Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(chatRoom.getRental().getId());
             String imgUrl = optionalImg.map(RentalImg::getImgUrl).orElse(null);
 
-            chatRoomResponseList.add(new ChatRoomListResponse(chatRoom, rentalState, recentMessage, imgUrl, opponent));
+            chatRoomResponseList.add(new ChatRoomListResponse(chatRoom, rentalInfo, recentMessage, imgUrl, opponent));
         }
         return chatRoomResponseList;
     }

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponse.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.HashMap;
+
 import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.SUCCESS;
 
 @Getter
@@ -43,5 +45,16 @@ public class BaseResponse<T> {
         this.isSuccess = status.isSuccess();
         this.message = message;
         this.code = status.getCode();       // 2000 고정
+    }
+
+    @SuppressWarnings("unchecked")
+    // 채팅방 생성 시 이미 존재하는 경우
+    public BaseResponse(BaseResponseStatus status, Long roomId) {
+        this.isSuccess = status.isSuccess();
+        this.message = status.getMessage();
+        this.code = status.getCode();
+        this.result = (T) new HashMap<String, Long>() {{
+            put("roomId", roomId);
+        }};
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/global/entity/ChatRoomException.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/ChatRoomException.java
@@ -1,0 +1,13 @@
+package com.yooyoung.clotheser.global.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomException extends Exception {
+    private BaseResponseStatus status;
+    private HttpStatus httpStatus;
+    private Long roomId;
+}

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
@@ -23,8 +23,6 @@ public class RentalResponse {
     private Boolean isWriter;
 
     // TODO: 팔로우 기능
-    private int followers = 0;
-    private int followees = 0;
 
     private List<String> imgUrls;
 
@@ -53,10 +51,6 @@ public class RentalResponse {
         this.profileUrl = rental.getUser().getProfileUrl();
         this.nickname = rental.getUser().getNickname();
         this.isWriter = rental.getUser().getId().equals(user.getId());
-
-        // TODO: 팔로우 기능
-        this.followers = 8;
-        this.followees = 5;
 
         this.imgUrls = imgUrls;
 

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalPriceRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalPriceRepository.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 @Repository
 public interface RentalPriceRepository extends JpaRepository<RentalPrice, Long> {
 
-    List<RentalPrice> findAllByRentalId(Long rentalId);
+    // 기간 적은 순으로 가격 정보 불러오기
+    List<RentalPrice> findAllByRentalIdOrderByDays(Long rentalId);
 
     @Query("select min(rp.price) from RentalPrice rp where rp.rental = :rental")
     Optional<Integer> findMinPrice(Rental rental);

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
@@ -91,9 +91,9 @@ public class RentalService {
             imgUrls.add(rentalImg.getImgUrl());
         }
 
-        // 가격 정보 불러오기
+        // 기간이 적은 순으로 가격 정보 불러오기
         List<RentalPriceDto> prices = new ArrayList<>();
-        List<RentalPrice> rentalPrices = rentalPriceRepository.findAllByRentalId(rentalId);
+        List<RentalPrice> rentalPrices = rentalPriceRepository.findAllByRentalIdOrderByDays(rentalId);
         for (RentalPrice rentalPrice : rentalPrices) {
             prices.add(new RentalPriceDto(rentalPrice.getDays(), rentalPrice.getPrice()));
         }

--- a/src/main/java/com/yooyoung/clotheser/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/user/dto/UserProfileResponse.java
@@ -18,8 +18,7 @@ public class UserProfileResponse {
     private int level;
     private int rentalCount;
 
-    private int followers = 0;
-    private int followees = 0;
+    // TODO: 팔로우 기능 추가
 
     private Integer height;
     private Integer weight;
@@ -35,10 +34,6 @@ public class UserProfileResponse {
 
         this.level = user.getUserLevel();
         this.rentalCount = user.getRentalCount();
-
-        // TODO: 팔로우 기능 추가
-        this.followers = 8;
-        this.followees = 5;
 
         this.height = user.getHeight();
         this.weight = user.getWeight();


### PR DESCRIPTION
## 🎯 관련 이슈
close #49 

<br>

## 📝 구현 내용
- [x] 대여글 조회: 대여 가격 리스트를 기간이 낮은 순으로 보여주기
- [x] 채팅방 목록 조회: 시간 형식 변경, 대여 시작일 & 반납 예정일 추가
- [x] 팔로워, 팔로잉 삭제 (추후 기능 추가 시 필요)
- [x] 채팅방 생성: 채팅방이 존재하는 경우 에러 메시지에 채팅방 id 추가

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
