### PR TITLE
대여글 삭제 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomListResponse.java
@@ -34,6 +34,8 @@ public class ChatRoomListResponse {
     private String title;
     @Schema(title = "대여글 썸네일 (첫 번째 사진)", example = "https://clotheser-s3-bucket.s3.ap-northeast-2.amazonaws.com/rentals/7c8adc06-7705-4323-90f2-3e2571eebbca_summer_nasi_3.jpg")
     private String rentalImgUrl;
+    @Schema(title = "대여글 삭제 여부", example = "false")
+    private Boolean isDeleted;
 
     @Schema(title = "대여 상태", example = "RENTED")
     private RentalState rentalState;
@@ -62,6 +64,7 @@ public class ChatRoomListResponse {
 
         this.title = chatRoom.getRental().getTitle();
         this.rentalImgUrl = rentalImgUrl;
+        this.isDeleted = chatRoom.getRental().getDeletedAt() != null;
 
         if (rentalInfo != null) {
             this.rentalState = rentalInfo.getState();

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
@@ -38,6 +38,8 @@ public class ChatRoomResponse {
     private String title;
     @Schema(title = "대여글 최소 가격", example = "1000")
     private Integer minPrice;
+    @Schema(title = "대여글 삭제 여부", example = "false")
+    private Boolean isDeleted;
 
     @Schema(title = "옷 상태 체크 여부", example = "true")
     private Boolean isChecked;
@@ -62,6 +64,7 @@ public class ChatRoomResponse {
         this.rentalImgUrl = rentalImgUrl;
         this.title = rental.getTitle();
         this.minPrice = minPrice;
+        this.isDeleted = chatRoom.getRental().getDeletedAt() != null;
     }
 
     /* 채팅방 조회 시 쓰는 생성자 */
@@ -78,6 +81,7 @@ public class ChatRoomResponse {
         this.rentalImgUrl = rentalImgUrl;
         this.title = chatRoom.getRental().getTitle();
         this.minPrice = minPrice;
+        this.isDeleted = chatRoom.getRental().getDeletedAt() != null;
 
         this.isChecked = isChecked;
         this.rentalState = rentalState;

--- a/src/main/java/com/yooyoung/clotheser/closet/dto/RentalHistoryResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/closet/dto/RentalHistoryResponse.java
@@ -32,6 +32,9 @@ public class RentalHistoryResponse {
     @Schema(title = "최소 가격", example = "2000")
     private int minPrice;
 
+    @Schema(title = "대여글 삭제 여부", example = "false")
+    private Boolean isDeleted;
+
     @Schema(title = "대여 상태", example = "RENTED")
     private RentalState rentalState;
 
@@ -49,6 +52,7 @@ public class RentalHistoryResponse {
         this.nickname = nickname;
         this.title = rental.getTitle();
         this.minPrice = minPrice;
+        this.isDeleted = rental.getDeletedAt() != null;
         this.rentalState = rentalInfo.getState();
         this.startDate = rentalInfo.getStartDate();
         this.endDate = rentalInfo.getEndDate();

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -52,6 +52,7 @@ public enum BaseResponseStatus {
     RENTAL_CHECK_EXISTS(false, 2204, "옷 상태는 한 번만 체크할 수 있습니다."),
     FORBIDDEN_CREATE_RENTAL_CHECK(false, 2205, "대여자만 옷 상태를 체크할 수 있습니다."),
     REQUEST_RENTAL_CHECK(false, 2206, "대여자가 옷 상태를 먼저 체크해야 대여할 수 있습니다."),
+    FORBIDEEN_DELETE_RENTAL(false, 2207, "대여 중인 경우에는 대여글을 삭제할 수 없습니다."),
 
     // 4. Chat (2300 ~ 2399)
     FORBIDDEN_CREATE_CHAT_ROOM(false, 2300, "대여글 작성자는 채팅방을 만들 수 없습니다."),

--- a/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
@@ -2,6 +2,7 @@ package com.yooyoung.clotheser.rental.controller;
 
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponse;
+import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
 import com.yooyoung.clotheser.rental.dto.*;
 import com.yooyoung.clotheser.rental.service.RentalService;
 import com.yooyoung.clotheser.user.domain.CustomUserDetails;
@@ -170,7 +171,7 @@ public class RentalController {
     @Operation(summary = "대여글 수정", description = "대여글을 수정한다.")
     @Parameter(name = "rentalId", description = "대여글 id", example = "1", required = true)
     @PutMapping(value = "/{rentalId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<BaseResponse<RentalResponse>> updateRentalPost(@Valid @RequestPart("post") RentalRequest rentalRequest,
+    public ResponseEntity<BaseResponse<RentalResponse>> updateRental(@Valid @RequestPart("post") RentalRequest rentalRequest,
                                                                          BindingResult bindingResult,
                                                                          @RequestPart(value = "images", required = false) MultipartFile[] images,
                                                                          @PathVariable Long rentalId,
@@ -190,6 +191,21 @@ public class RentalController {
             }
 
             return new ResponseEntity<>(new BaseResponse<>(rentalService.updateRental(rentalRequest, images, userDetails.user, rentalId)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
+    /* 대여글 삭제 */
+    @Operation(summary = "대여글 삭제", description = "대여글을 삭제한다.")
+    @Parameter(name = "rentalId", description = "대여글 id", example = "1", required = true)
+    @DeleteMapping("/{rentalId}")
+    public ResponseEntity<BaseResponse<BaseResponseStatus>> deleteRental(@PathVariable("rentalId") Long rentalId,
+                                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            User user = userDetails.user;
+            return new ResponseEntity<>(new BaseResponse<>(rentalService.deleteRental(rentalId, user)), OK);
         }
         catch (BaseException exception) {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());

--- a/src/main/java/com/yooyoung/clotheser/rental/domain/Rental.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/domain/Rental.java
@@ -85,4 +85,9 @@ public class Rental {
         return this;
     }
 
+    public Rental deleteRental() {
+        this.deletedAt = LocalDateTime.now();
+        return this;
+    }
+
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalCheckRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalCheckRequest.java
@@ -2,7 +2,7 @@ package com.yooyoung.clotheser.rental.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.util.List;
@@ -14,7 +14,7 @@ public class RentalCheckRequest {
     @Schema(title = "옷 상태 체크리스트", description = "255자 이내", type = "array",
             example = "[\"오른쪽 소매에 오염 있음\", \"구김 있음\"]", requiredMode = Schema.RequiredMode.REQUIRED)
     @Valid
-    @NotEmpty(message = "옷 상태를 입력해주세요.")
+    @NotBlank(message = "옷 상태를 입력해주세요.")
     private List<String> checkList;
 
 }

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
@@ -27,4 +27,7 @@ public interface RentalInfoRepository extends JpaRepository<RentalInfo, Long> {
             "CASE WHEN r.state = com.yooyoung.clotheser.rental.domain.RentalState.RENTED THEN 0 ELSE 1 END, r.startDate DESC")
     List<RentalInfo> findAllByBuyerIdOrderByStateAndRentalDate(@Param("userId") Long userId);
 
+    // 대여 중인지 확인
+    boolean existsByRentalIdAndState(Long rentalId, RentalState state);
+
 }


### PR DESCRIPTION
## 🎯 관련 이슈
close #73 

<br>

## 📝 구현 내용
- [x] 대여글 삭제 API 개발
  - 대여글 자체는 논리 삭제
  - 대여글 이미지와 가격표는 물리 삭제
- [x] 대여글 목록 조회 시 삭제된 대여글 배제 확인
- [x] 대여글 삭제 여부 응답값에 추가 (ex. 채팅방 목록/상세 조회, 공유/대여 내역 조회)

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
