### PR TITLE
거래 후기 생성 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/ChatRoomResponse.java
@@ -47,6 +47,9 @@ public class ChatRoomResponse {
     @Schema(title = "대여 상태", example = "RETURNED")
     private RentalState rentalState;
 
+    @Schema(title = "후기 작성 여부", example = "true")
+    private Boolean isReviewed;
+
     @Schema(description = "채팅 메시지 목록", type = "array")
     private List<ChatMessageResponse> messages;
 
@@ -69,7 +72,7 @@ public class ChatRoomResponse {
 
     /* 채팅방 조회 시 쓰는 생성자 */
     public ChatRoomResponse(ChatRoom chatRoom, String opponentSid, String opponentNickname, List<ChatMessageResponse> messages,
-                            String rentalImgUrl, Integer minPrice, Boolean isChecked, RentalState rentalState) {
+                            String rentalImgUrl, Integer minPrice, Boolean isChecked, RentalState rentalState, Boolean isReviewed) {
         this.id = chatRoom.getId();
         this.buyerNickname = chatRoom.getBuyer().getNickname();
         this.lenderNickname = chatRoom.getLender().getNickname();
@@ -85,6 +88,7 @@ public class ChatRoomResponse {
 
         this.isChecked = isChecked;
         this.rentalState = rentalState;
+        this.isReviewed = isReviewed;
         this.messages = messages;
     }
 

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -52,6 +52,7 @@ public enum BaseResponseStatus {
     FORBIDDEN_CREATE_RENTAL_CHECK(false, 2205, "대여자만 옷 상태를 체크할 수 있습니다."),
     REQUEST_RENTAL_CHECK(false, 2206, "대여자가 옷 상태를 먼저 체크해야 대여할 수 있습니다."),
     FORBIDEEN_DELETE_RENTAL(false, 2207, "대여 중인 경우에는 대여글을 삭제할 수 없습니다."),
+    REVIEW_EXISTS(false, 2208, "거래 후기는 한 번만 작성할 수 있습니다."),
 
     // 4. Chat (2300 ~ 2399)
     FORBIDDEN_CREATE_CHAT_ROOM(false, 2300, "대여글 작성자는 채팅방을 만들 수 없습니다."),

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -47,7 +47,6 @@ public enum BaseResponseStatus {
     // 3. Rental (2200 ~ 2299)
     EMPTY_CLOTHES_ID(false, 2200, "보유 옷 id가 필요합니다."),
     FORBIDDEN_CREATE_RENTAL_INFO(false, 2201, "판매자만 대여 정보를 입력할 수 있습니다."),
-    FORBIDDEN_UPDATE_RENTAL_INFO(false, 2202, "판매자만 대여 정보를 수정할 수 있습니다."),
     TOO_MANY_IMAGES(false, 2203, "대여글 이미지는 최대 3장까지 첨부할 수 있습니다."),
     RENTAL_CHECK_EXISTS(false, 2204, "옷 상태는 한 번만 체크할 수 있습니다."),
     FORBIDDEN_CREATE_RENTAL_CHECK(false, 2205, "대여자만 옷 상태를 체크할 수 있습니다."),

--- a/src/main/java/com/yooyoung/clotheser/rental/domain/Rental.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/domain/Rental.java
@@ -34,7 +34,7 @@ public class Rental {
     // TODO: 필요 시 보유 옷 FK 걸기
     private Long clothesId;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 50)
     private String title;
 
     @Column(nullable = false, length = 500)

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface RentalInfoRepository extends JpaRepository<RentalInfo, Long> {
 
-    // 채팅방 조회: 제일 최근 대여 정보에서 대여 상태 불러오기
+    // 최근 대여 정보 찾기
     Optional<RentalInfo> findFirstByBuyerIdAndLenderIdAndRentalIdOrderByRentalTimeDesc(Long buyerId, Long lenderId, Long rentalId);
 
     // 반납: 대여 중인 대여 정보 찾기

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
@@ -271,11 +271,6 @@ public class RentalService {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_CHAT_ROOM, NOT_FOUND));
 
-        // 판매자인지 확인
-        if (!chatRoom.getLender().getId().equals(user.getId()) ) {
-            throw new BaseException(FORBIDDEN_UPDATE_RENTAL_INFO, FORBIDDEN);
-        }
-
         // 대여 상태인 대여 정보 불러오기
         RentalInfo rentalInfo = rentalInfoRepository.findFirstByBuyerIdAndLenderIdAndRentalIdAndState(
                 chatRoom.getBuyer().getId(),

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalService.java
@@ -271,6 +271,11 @@ public class RentalService {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_CHAT_ROOM, NOT_FOUND));
 
+        // 채팅방 참여자인지 확인
+        if (!chatRoom.getBuyer().getId().equals(user.getId()) && !chatRoom.getLender().getId().equals(user.getId()) ) {
+            throw new BaseException(FORBIDDEN_ENTER_CHAT_ROOM, FORBIDDEN);
+        }
+
         // 대여 상태인 대여 정보 불러오기
         RentalInfo rentalInfo = rentalInfoRepository.findFirstByBuyerIdAndLenderIdAndRentalIdAndState(
                 chatRoom.getBuyer().getId(),

--- a/src/main/java/com/yooyoung/clotheser/review/controller/ReviewController.java
+++ b/src/main/java/com/yooyoung/clotheser/review/controller/ReviewController.java
@@ -1,0 +1,57 @@
+package com.yooyoung.clotheser.review.controller;
+
+import com.yooyoung.clotheser.global.entity.BaseException;
+import com.yooyoung.clotheser.global.entity.BaseResponse;
+import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
+import com.yooyoung.clotheser.review.dto.ReviewRequest;
+import com.yooyoung.clotheser.review.service.ReviewService;
+import com.yooyoung.clotheser.user.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.REQUEST_ERROR;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reviews")
+@Tag(name = "Review", description = "거래 후기 API")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "거래 후기 생성", description = "상대방에 대한 거래 후기를 작성한다.")
+    @Parameter(name = "roomId", description = "채팅방 id", example = "1", required = true)
+    @PostMapping("/{roomId}")
+    public ResponseEntity<BaseResponse<BaseResponseStatus>> createReview(@PathVariable Long roomId,
+                                                                         @Valid @RequestBody ReviewRequest reviewRequest,
+                                                                         BindingResult bindingResult,
+                                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            // 입력 유효성 검사
+            if (bindingResult.hasErrors()) {
+                List<FieldError> list = bindingResult.getFieldErrors();
+                for(FieldError error : list) {
+                    return new ResponseEntity<>(new BaseResponse<>(REQUEST_ERROR, error.getDefaultMessage()), BAD_REQUEST);
+                }
+            }
+
+            return new ResponseEntity<>(new BaseResponse<>(reviewService.createReview(roomId, reviewRequest, userDetails.user)), CREATED);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/review/domain/Keyword.java
+++ b/src/main/java/com/yooyoung/clotheser/review/domain/Keyword.java
@@ -1,0 +1,59 @@
+package com.yooyoung.clotheser.review.domain;
+
+import lombok.Getter;
+
+public enum Keyword {
+
+    /*
+        긍정 키워드
+    */
+    // 1. 공통
+    KIND(true, "common", 1, "친절해요"),
+    ON_TIME(true, "common", 2, "시간 약속을 잘 지켜요"),
+    FAST_RESPONSE(true, "common", 1, "응답(연락)이 빨라요"),
+
+    // 2. 판매자
+    GOOD_CLOTHES_STATE(true, "lender", 2, "옷 상태가 좋아요"),
+    CHEAP_PRICE(true, "lender", 1, "대여 가격이 비교적 저렴해요"),
+    DETAIL_DESCRIPTION(true, "lender", 1, "상품 설명이 자세해요"),
+    MATCHED_DESCRIPTION(true, "lender", 2, "상품 설명과 실제 상품이 동일해요"),
+
+    // 3. 대여자
+    CLEAN_RETURN(true, "buyer", 2, "깨끗하게 입고 반납했어요"),
+    ON_RETURN_DATE(true, "buyer", 2, "반납일을 잘 지켜요"),
+
+    /*
+        부정 키워드
+    */
+    // 1. 공통
+    UNKIND(false, "common", -1, "불친절해요"),
+    NOT_ON_TIME(false, "common", -3, "시간 약속을 어겼어요"),
+    SLOW_RESPONSE(false, "common", -2, "연락을 잘 받지 않아요"),
+
+    // 2. 판매자
+    BAD_CLOTHES_STATE(false, "lender", -3, "옷 상태가 좋지 않아요"),
+    EXPENSIVE_PRICE(false, "lender", -1, "대여 가격이 비싸요"),
+    MISMATCHED_DESCRIPTION(false, "lender", -2, "상품 설명과 실제 상품이 달라요"),
+
+    // 3. 대여자
+    DIRTY_RETURN(false, "buyer", -3, "반납할 때 옷 상태가 좋지 않아요"),
+    NOT_ON_RETURN_DATE(false, "buyer", -3, "반납일을 어겼어요");
+
+    private final boolean isPositive;
+    private final String userRole;
+    @Getter
+    private final int score;
+    private final String description;
+
+    Keyword(boolean isPositive, String userRole , int score, String description) {
+        this.isPositive = isPositive;
+        this.userRole = userRole;
+        this.score = score;
+        this.description = description;
+    }
+
+    public boolean getIsPositive() {
+        return isPositive;
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/review/domain/Review.java
+++ b/src/main/java/com/yooyoung/clotheser/review/domain/Review.java
@@ -1,0 +1,49 @@
+package com.yooyoung.clotheser.review.domain;
+
+import com.yooyoung.clotheser.rental.domain.RentalInfo;
+import com.yooyoung.clotheser.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(unique = true, nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private RentalInfo rentalInfo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User reviewee;
+
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    private Boolean isPositive;
+
+    @Column(length = 500)
+    private String content;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/yooyoung/clotheser/review/domain/ReviewKeyword.java
+++ b/src/main/java/com/yooyoung/clotheser/review/domain/ReviewKeyword.java
@@ -1,0 +1,25 @@
+package com.yooyoung.clotheser.review.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(unique = true, nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Review review;
+
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    private Keyword keyword;
+
+}

--- a/src/main/java/com/yooyoung/clotheser/review/dto/ReviewRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/review/dto/ReviewRequest.java
@@ -1,0 +1,46 @@
+package com.yooyoung.clotheser.review.dto;
+
+import com.yooyoung.clotheser.rental.domain.RentalInfo;
+import com.yooyoung.clotheser.review.domain.Keyword;
+import com.yooyoung.clotheser.review.domain.Review;
+import com.yooyoung.clotheser.review.domain.ReviewKeyword;
+import com.yooyoung.clotheser.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class ReviewRequest {
+
+    @Schema(title = "후기 키워드 리스트", type = "array", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Valid
+    @NotEmpty(message = "키워드를 선택해주세요.")
+    private List<Keyword> keywords;
+
+    @Schema(title = "후기 텍스트", description = "500자 이내", example = "옷 상태도 좋고 저렴한 가격으로 새로운 옷을 입어볼 수 있었어요! 감사합니다 :)")
+    private String content;
+
+    public Review toReviewEntity(RentalInfo rentalInfo, User reviewer, User reviewee) {
+        return Review.builder()
+                .rentalInfo(rentalInfo)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .isPositive(this.keywords.get(0).getIsPositive())
+                .content(this.content)
+                .build();
+    }
+
+    public ReviewKeyword toReviewKeywordEntity(Review review, Keyword keyword) {
+        return ReviewKeyword.builder()
+                .review(review)
+                .keyword(keyword)
+                .build();
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/review/repository/ReviewKeywordRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/review/repository/ReviewKeywordRepository.java
@@ -1,0 +1,15 @@
+package com.yooyoung.clotheser.review.repository;
+
+import com.yooyoung.clotheser.review.domain.ReviewKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReviewKeywordRepository extends JpaRepository<ReviewKeyword, Long> {
+
+    // 키워드 가져오기
+    List<ReviewKeyword> findAllByReviewId(Long reviewId);
+
+}

--- a/src/main/java/com/yooyoung/clotheser/review/repository/ReviewRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/review/repository/ReviewRepository.java
@@ -1,0 +1,21 @@
+package com.yooyoung.clotheser.review.repository;
+
+import com.yooyoung.clotheser.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    // 기존에 후기를 작성했었는지 확인
+    boolean existsByRentalInfoIdAndReviewerId(Long rentalInfoId, Long reviewerId);
+
+    // 받은 후기 건수 확인
+    int countByRevieweeId(Long revieweeId);
+
+    // 최근 후기 3건 가져오기
+    List<Review> findTop3ByRevieweeIdOrderByCreatedAtDesc(Long revieweeId);
+
+}

--- a/src/main/java/com/yooyoung/clotheser/review/service/ReviewService.java
+++ b/src/main/java/com/yooyoung/clotheser/review/service/ReviewService.java
@@ -1,0 +1,113 @@
+package com.yooyoung.clotheser.review.service;
+
+import com.yooyoung.clotheser.chat.domain.ChatRoom;
+import com.yooyoung.clotheser.chat.repository.ChatRoomRepository;
+import com.yooyoung.clotheser.global.entity.BaseException;
+import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
+import com.yooyoung.clotheser.rental.domain.RentalInfo;
+import com.yooyoung.clotheser.rental.domain.RentalState;
+import com.yooyoung.clotheser.rental.repository.RentalInfoRepository;
+import com.yooyoung.clotheser.review.domain.Keyword;
+import com.yooyoung.clotheser.review.domain.Review;
+import com.yooyoung.clotheser.review.domain.ReviewKeyword;
+import com.yooyoung.clotheser.review.dto.ReviewRequest;
+import com.yooyoung.clotheser.review.repository.ReviewKeywordRepository;
+import com.yooyoung.clotheser.review.repository.ReviewRepository;
+import com.yooyoung.clotheser.user.domain.User;
+import com.yooyoung.clotheser.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.NOT_FOUND_RENTAL_INFO;
+import static org.springframework.http.HttpStatus.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final RentalInfoRepository rentalInfoRepository;
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final ReviewKeywordRepository reviewKeywordRepository;
+
+    // 거래 후기 생성
+    public BaseResponseStatus createReview(Long roomId, ReviewRequest reviewRequest, User user) throws BaseException {
+
+        // 최초 로그인이 아닌지 확인
+        if (user.getIsFirstLogin()) {
+            throw new BaseException(REQUEST_FIRST_LOGIN, FORBIDDEN);
+        }
+
+        // 채팅방 존재 확인
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_CHAT_ROOM, NOT_FOUND));
+
+        // 채팅방 참여자인지 확인
+        if (!chatRoom.getBuyer().getId().equals(user.getId()) && !chatRoom.getLender().getId().equals(user.getId()) ) {
+            throw new BaseException(FORBIDDEN_ENTER_CHAT_ROOM, FORBIDDEN);
+        }
+
+        // 대여 완료 상태인 대여 정보 불러오기
+        RentalInfo rentalInfo = rentalInfoRepository.findFirstByBuyerIdAndLenderIdAndRentalIdAndState(
+                chatRoom.getBuyer().getId(),
+                chatRoom.getLender().getId(),
+                chatRoom.getRental().getId(),
+                RentalState.RETURNED
+        ).orElseThrow(() -> new BaseException(NOT_FOUND_RENTAL_INFO, NOT_FOUND));
+
+        // 기존에 후기를 작성했었는지 확인
+        if (reviewRepository.existsByRentalInfoIdAndReviewerId(rentalInfo.getId(), user.getId())) {
+            throw new BaseException(REVIEW_EXISTS, CONFLICT);
+        }
+
+        // 작성한 후기 저장
+        User reviewee = rentalInfo.getBuyer().getId().equals(user.getId()) ? rentalInfo.getLender() : rentalInfo.getBuyer();
+
+        Review review = reviewRequest.toReviewEntity(rentalInfo, user, reviewee);
+        reviewRepository.save(review);
+
+        List<Keyword> keywords = reviewRequest.getKeywords();
+        for (Keyword keyword : keywords) {
+            ReviewKeyword reviewKeyword = reviewRequest.toReviewKeywordEntity(review, keyword);
+            reviewKeywordRepository.save(reviewKeyword);
+        }
+
+        // 상대방의 옷장 점수 반영
+        updateClosetScore(reviewee);
+        userRepository.save(reviewee);
+
+        return SUCCESS;
+    }
+
+    // 누적 후기 건수가 3건일 때마다, 옷장 점수 변경
+    public void updateClosetScore(User user) {
+
+        int reviewCount = reviewRepository.countByRevieweeId(user.getId());
+
+        if (reviewCount % 3 == 0 && reviewCount > 0) {
+            // 최근 3건 가져와서 평균 구하기
+            List<Long> reviewIds = reviewRepository.findTop3ByRevieweeIdOrderByCreatedAtDesc(user.getId())
+                    .stream()
+                    .map(Review::getId)
+                    .toList();
+            double difference = 0;
+            for (Long reviewId : reviewIds) {
+                // 키워드별 점수 합치기
+                List<Keyword> keywords = reviewKeywordRepository.findAllByReviewId(reviewId)
+                        .stream()
+                        .map(ReviewKeyword::getKeyword)
+                        .toList();
+                difference += keywords.stream().mapToDouble(Keyword::getScore).sum();
+            }
+            difference = difference / 3 * 0.1;
+            user.updateClosetScore(difference);
+        }
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -67,7 +67,7 @@ public class User {
 
     @ColumnDefault("10")
     @Builder.Default
-    private int closetScore = 10;
+    private double closetScore = 10;
 
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     @ColumnDefault("true")      // DB 기본값 설정
@@ -173,6 +173,15 @@ public class User {
         this.shoeSize = userStyleRequest.getShoeSize();
         this.updatedAt = LocalDateTime.now();
         return this;
+    }
+
+    // 옷장 점수 수정
+    public void updateClosetScore(double difference) {
+        this.closetScore += difference;
+        if (this.closetScore > 20)
+            this.closetScore = 20;
+        else if (this.closetScore < 0)
+            this.closetScore = 0;
     }
 
 }

--- a/src/main/java/com/yooyoung/clotheser/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/user/dto/response/UserProfileResponse.java
@@ -8,6 +8,8 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -26,7 +28,7 @@ public class UserProfileResponse {
     @Schema(title = "대여 횟수", example = "4")
     private int rentalCount;
     @Schema(title = "옷장 점수", example = "10")
-    private int closetScore;
+    private double closetScore;
 
     @Schema(title = "성별", example = "FEMALE")
     private Gender gender;
@@ -54,7 +56,15 @@ public class UserProfileResponse {
 
         this.level = user.getUserLevel();
         this.rentalCount = user.getRentalCount();
-        this.closetScore = user.getClosetScore();
+
+        double closetScore = user.getClosetScore();
+        if (closetScore == (int) closetScore) {
+            this.closetScore = Double.parseDouble(String.format("%d", (int) closetScore));
+        }
+        else {
+            BigDecimal bd = new BigDecimal(closetScore).setScale(1, RoundingMode.DOWN);
+            this.closetScore = bd.doubleValue();
+        }
 
         this.gender = user.getGender();
         this.height = user.getHeight();


### PR DESCRIPTION
## 🎯 관련 이슈
close #79 

<br>

## 📝 구현 내용
- [x] 대여 완료된 거래에서 후기 한 번만 작성 가능
- [x] 후기 3개씩 쌓일 때마다 옷장 점수 반영
- [x] 프로필 조회 시 옷장 점수는 소수점 둘째 자리에서 버림
- [x] 채팅방 조회 시 후기 작성 여부(isReviewed) 추가
- [x] 반납하기 API는 모두 접근 가능하게 변경

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
