### PR TITLE
보유 옷 생성 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/clothes/controller/ClothesController.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/controller/ClothesController.java
@@ -49,6 +49,10 @@ public class ClothesController {
                 }
             }
 
+            if (images == null) {
+                images = new MultipartFile[0];
+            }
+
             // 보유 옷 이미지 최대 3장
             if (images.length > 3) {
                 throw new BaseException(TOO_MANY_CLOTHES_IMAGES, PAYLOAD_TOO_LARGE);

--- a/src/main/java/com/yooyoung/clotheser/clothes/controller/ClothesController.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/controller/ClothesController.java
@@ -1,0 +1,64 @@
+package com.yooyoung.clotheser.clothes.controller;
+
+import com.yooyoung.clotheser.clothes.dto.ClothesRequest;
+import com.yooyoung.clotheser.clothes.dto.ClothesResponse;
+import com.yooyoung.clotheser.clothes.service.ClothesService;
+import com.yooyoung.clotheser.global.entity.BaseException;
+import com.yooyoung.clotheser.global.entity.BaseResponse;
+import com.yooyoung.clotheser.user.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
+import static org.springframework.http.HttpStatus.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/clothes")
+@Tag(name = "Clothes", description = "옷장 구경 API")
+public class ClothesController {
+
+    private final ClothesService clothesService;
+
+    @Operation(summary = "보유 옷 생성", description = "보유 옷을 생성한다.")
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<ClothesResponse>> createClothes(@Valid @RequestPart("clothes") ClothesRequest clothesRequest,
+                                                                       BindingResult bindingResult,
+                                                                       @RequestPart(value = "images", required = false) MultipartFile[] images,
+                                                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            // 입력 유효성 검사
+            if (bindingResult.hasErrors()) {
+                List<FieldError> list = bindingResult.getFieldErrors();
+                for(FieldError error : list) {
+                    return new ResponseEntity<>(new BaseResponse<>(REQUEST_ERROR, error.getDefaultMessage()), BAD_REQUEST);
+                }
+            }
+
+            // 보유 옷 이미지 최대 3장
+            if (images.length > 3) {
+                throw new BaseException(TOO_MANY_CLOTHES_IMAGES, PAYLOAD_TOO_LARGE);
+            }
+
+            return new ResponseEntity<>(new BaseResponse<>(clothesService.createClothes(clothesRequest, images, userDetails.user)), CREATED);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/clothes/domain/Clothes.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/domain/Clothes.java
@@ -33,11 +33,17 @@ public class Clothes {
     @Column(nullable = false, length = 50)
     private String name;
 
+    @Column(nullable = false, length = 500)
+    private String description;
+
     @Column(columnDefinition = "TINYINT(1)")
     private Gender gender;
 
     @Column(length = 10)
     private String category;
+
+    @Column(length = 20)
+    private String style;
 
     private Integer price;
 
@@ -48,9 +54,6 @@ public class Clothes {
     private String size;
 
     private String shoppingUrl;
-
-    @Column(nullable = false, length = 500)
-    private String description;
 
     @Column(columnDefinition = "TINYINT(1)", nullable = false)
     @ColumnDefault("true")

--- a/src/main/java/com/yooyoung/clotheser/clothes/domain/Clothes.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/domain/Clothes.java
@@ -1,0 +1,72 @@
+package com.yooyoung.clotheser.clothes.domain;
+
+import com.yooyoung.clotheser.user.domain.Gender;
+import com.yooyoung.clotheser.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@DynamicUpdate
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Clothes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(unique = true, nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(columnDefinition = "TINYINT(1)")
+    private Gender gender;
+
+    @Column(length = 10)
+    private String category;
+
+    private Integer price;
+
+    @Column(length = 20)
+    private String brand;
+
+    @Column(length = 10)
+    private String size;
+
+    private String shoppingUrl;
+
+    @Column(nullable = false, length = 500)
+    private String description;
+
+    @Column(columnDefinition = "TINYINT(1)", nullable = false)
+    @ColumnDefault("true")
+    private Boolean isPublic;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @ColumnDefault("null")
+    private LocalDateTime updatedAt;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @ColumnDefault("null")
+    private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/yooyoung/clotheser/clothes/domain/ClothesImg.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/domain/ClothesImg.java
@@ -1,0 +1,25 @@
+package com.yooyoung.clotheser.clothes.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClothesImg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(unique = true, nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Clothes clothes;
+
+    @Column(nullable = false)
+    private String imgUrl;
+
+}

--- a/src/main/java/com/yooyoung/clotheser/clothes/dto/ClothesRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/dto/ClothesRequest.java
@@ -1,0 +1,67 @@
+package com.yooyoung.clotheser.clothes.dto;
+
+import com.yooyoung.clotheser.clothes.domain.Clothes;
+import com.yooyoung.clotheser.user.domain.Gender;
+import com.yooyoung.clotheser.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class ClothesRequest {
+
+    @Schema(title = "상품명", description = "50자 이내", example = "스퀘어 아이보리 블라우스", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "상품명을 입력해주세요.")
+    @Size(max = 50, message = "상품명은 50자 이내로 입력해주세요.")
+    private String name;
+
+    @Schema(title = "옷 후기", description = "500자 이내", example = "허리 라인에 밴딩이 있어서 활동성이 좋아요!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "옷 후기를 입력해주세요.")
+    @Size(max = 500, message = "옷 후기는 500자 이내로 입력해주세요.")
+    private String description;
+
+    @Schema(title = "성별", example = "FEMALE")
+    private Gender gender;
+
+    @Schema(title = "카테고리", description = "10자 이내", example = "블라우스")
+    private String category;
+
+    @Schema(title = "스타일", example = "캐주얼")
+    private String style;
+
+    @Schema(title = "구매 가격", example = "19900")
+    private Integer price;
+
+    @Schema(title = "브랜드", description = "20자 이내", example = "에이블리")
+    private String brand;
+
+    @Schema(title = "사이즈", description = "10자 이내 (숫자도 가능)", example = "FREE")
+    private String size;
+
+    @Schema(title = "구매처 링크", example = "https://m.a-bly.com/goods/7995907")
+    private String shoppingUrl;
+
+    @Schema(title = "공개 여부", example = "true", defaultValue = "true")
+    private Boolean isPublic = true;
+
+    public Clothes toEntity(User user) {
+        return Clothes.builder()
+                .user(user)
+                .name(name)
+                .description(description)
+                .gender(gender)
+                .category(category)
+                .style(style)
+                .price(price)
+                .brand(brand)
+                .size(size)
+                .shoppingUrl(shoppingUrl)
+                .isPublic(isPublic)
+                .build();
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/clothes/dto/ClothesResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/dto/ClothesResponse.java
@@ -1,0 +1,106 @@
+package com.yooyoung.clotheser.clothes.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.yooyoung.clotheser.clothes.domain.Clothes;
+import com.yooyoung.clotheser.user.domain.Gender;
+import com.yooyoung.clotheser.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class ClothesResponse {
+
+    @Schema(title = "보유 옷 id", example = "1")
+    private Long id;
+
+    // 회원 정보
+    @Schema(title = "암호화된 회원 id", example = "M0h1QXdzUlVzNkRwckdUeUEvbjVQZz09")
+    private String userSid;
+
+    @Schema(title = "작성자 프로필 사진 URL", example = "https://clotheser-s3-bucket.s3.ap-northeast-2.amazonaws.com/profiles/noonsong.png")
+    private String profileUrl;
+
+    @Schema(title = "작성자 닉네임", example = "김눈송")
+    private String nickname;
+
+    @Schema(title = "작성자 여부", example = "false")
+    private Boolean isWriter;
+
+    // 보유 옷 정보
+    @Schema(title = "보유 옷 사진 URL 목록", description = "최대 3장", type = "array",
+            example = "[\"https://clotheser-s3-bucket.s3.ap-northeast-2.amazonaws.com/clothess/0fa7d4e0-de3d-4c87-a814-cc0ee8b8a8fe_black_ops%281%29.jpg\"]")
+    private List<String> imgUrls;
+
+    @Schema(title = "상품명", example = "스퀘어 아이보리 블라우스")
+    private String name;
+
+    @Schema(title = "옷 후기", example = "허리 라인에 밴딩이 있어서 활동성이 좋아요!")
+    private String description;
+
+    @Schema(title = "성별", example = "FEMALE")
+    private Gender gender;
+
+    @Schema(title = "카테고리", example = "블라우스")
+    private String category;
+
+    @Schema(title = "스타일", example = "캐주얼")
+    private String style;
+
+    @Schema(title = "구매 가격", example = "19,900")
+    private Integer price;
+
+    @Schema(title = "브랜드", example = "에이블리")
+    private String brand;
+
+    @Schema(title = "사이즈", example = "FREE")
+    private String size;
+
+    @Schema(title = "구매처 링크", example = "https://m.a-bly.com/goods/7995907")
+    private String shoppingUrl;
+
+    @Schema(title = "공개 여부", example = "true")
+    private Boolean isPublic;
+
+    @Schema(title = "보유 옷 생성 시간", example = "2024년 06월 20일 17:55:40")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+
+    @Schema(title = "보유 옷 수정 시간", description = "수정 안 하면 null", example = "2024년 06월 21일 21:40:51")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime updatedAt;
+
+    public ClothesResponse(User user, String userSid, Clothes clothes, List<String> imgUrls) {
+        this.id = clothes.getId();
+        this.userSid = userSid;
+        this.profileUrl = clothes.getUser().getProfileUrl();
+        this.nickname = clothes.getUser().getNickname();
+        this.isWriter = clothes.getUser().getId().equals(user.getId());
+
+        this.imgUrls = imgUrls;
+
+        this.name = clothes.getName();
+        this.description = clothes.getDescription();
+
+        this.gender = clothes.getGender();
+        this.category = clothes.getCategory();
+        this.style = clothes.getStyle();
+
+        this.price = clothes.getPrice();
+        this.brand = clothes.getBrand();
+        this.size = clothes.getSize();
+        this.shoppingUrl = clothes.getShoppingUrl();
+        this.isPublic = clothes.getIsPublic();
+
+        this.createdAt = clothes.getCreatedAt();
+        this.updatedAt = clothes.getUpdatedAt();
+    }
+    
+    
+}

--- a/src/main/java/com/yooyoung/clotheser/clothes/repository/ClothesImgRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/repository/ClothesImgRepository.java
@@ -1,10 +1,9 @@
 package com.yooyoung.clotheser.clothes.repository;
 
-import com.yooyoung.clotheser.clothes.domain.Clothes;
+import com.yooyoung.clotheser.clothes.domain.ClothesImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ClothesRepository extends JpaRepository<Clothes, Long> {
-
+public interface ClothesImgRepository extends JpaRepository<ClothesImg, Long> {
 }

--- a/src/main/java/com/yooyoung/clotheser/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/repository/ClothesRepository.java
@@ -4,7 +4,11 @@ import com.yooyoung.clotheser.clothes.domain.Clothes;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ClothesRepository extends JpaRepository<Clothes, Long> {
 
+    // 보유 옷 조회
+    Optional<Clothes> findByIdAndDeletedAtNull(Long id);
 }

--- a/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesImageService.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesImageService.java
@@ -37,8 +37,8 @@ public class ClothesImageService {
     public List<String> uploadClothesImages(MultipartFile[] images, Clothes clothes) throws BaseException {
         List<String> imgUrls = new ArrayList<>();
 
-        // 보유 옷 이미지 없는 경우
-        if (images[0].isEmpty()) {
+        // 보유 옷 이미지 없는 경우 (1: Swaager, 2: Postman)
+        if (images.length == 0 || images[0].isEmpty()) {
             return null;
         }
 

--- a/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesImageService.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesImageService.java
@@ -1,0 +1,90 @@
+package com.yooyoung.clotheser.clothes.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.yooyoung.clotheser.clothes.domain.Clothes;
+import com.yooyoung.clotheser.clothes.domain.ClothesImg;
+import com.yooyoung.clotheser.clothes.repository.ClothesImgRepository;
+import com.yooyoung.clotheser.global.entity.BaseException;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.S3_UPLOAD_ERROR;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class ClothesImageService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final ClothesImgRepository clothesImgRepository;
+
+    /* 보유 옷 이미지 저장 */
+    public List<String> uploadClothesImages(MultipartFile[] images, Clothes clothes) throws BaseException {
+        List<String> imgUrls = new ArrayList<>();
+
+        // 보유 옷 이미지 없는 경우
+        if (images[0].isEmpty()) {
+            return null;
+        }
+
+        try {
+            for (MultipartFile image : images) {
+                // 파일명 중복 방지 위해 랜덤 숫자 추가
+                String fileName = "clothes/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
+
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(image.getSize());
+                metadata.setContentType(image.getContentType());
+
+                amazonS3.putObject(bucket, fileName, image.getInputStream(), metadata);
+                String imgUrl = amazonS3.getUrl(bucket, fileName).toString();
+                imgUrls.add(imgUrl);
+
+                // 데이터베이스에 이미지 URL 저장
+                ClothesImg clothesImg = ClothesImg.builder()
+                        .imgUrl(imgUrl)
+                        .clothes(clothes)
+                        .build();
+
+                clothesImgRepository.save(clothesImg);
+            }
+        } catch (IOException e) {
+            throw new BaseException(S3_UPLOAD_ERROR, INTERNAL_SERVER_ERROR);
+        }
+
+        return imgUrls;
+    }
+
+    /* 보유 옷 이미지 삭제 */
+    public void deleteClothesImages(List<ClothesImg> clothesImgs) {
+        // S3에서 삭제
+        for (ClothesImg clothesImg : clothesImgs) {
+            String fileName = clothesImg.getImgUrl().substring(clothesImg.getImgUrl().lastIndexOf("/") + 1);
+            String decodedFileName= URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+            amazonS3.deleteObject(bucket, "clothes/" + decodedFileName);
+        }
+
+        // DB에서 삭제
+        List<Long> clothesImgIds = clothesImgs.stream()
+                .map(ClothesImg::getId)
+                .toList();
+        clothesImgRepository.deleteAllByIdInBatch(clothesImgIds);
+    }
+
+
+}

--- a/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesService.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesService.java
@@ -1,0 +1,65 @@
+package com.yooyoung.clotheser.clothes.service;
+
+import com.yooyoung.clotheser.clothes.domain.Clothes;
+import com.yooyoung.clotheser.clothes.dto.ClothesRequest;
+import com.yooyoung.clotheser.clothes.dto.ClothesResponse;
+import com.yooyoung.clotheser.clothes.repository.ClothesRepository;
+import com.yooyoung.clotheser.global.entity.BaseException;
+import com.yooyoung.clotheser.global.util.AESUtil;
+import com.yooyoung.clotheser.global.util.Base64UrlSafeUtil;
+import com.yooyoung.clotheser.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.FAIL_TO_ENCRYPT;
+import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.REQUEST_FIRST_LOGIN;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ClothesService {
+
+    @Autowired
+    private AESUtil aesUtil;
+    @Value("${aes.key}")
+    private String AES_KEY;
+
+    private final ClothesRepository clothesRepository;
+    private final ClothesImageService clothesImageService;
+
+    /* 보유 옷 생성 */
+    public ClothesResponse createClothes(ClothesRequest clothesRequest, MultipartFile[] images, User user) throws BaseException {
+
+        // 최초 로그인이 아닌지 확인
+        if (user.getIsFirstLogin()) {
+            throw new BaseException(REQUEST_FIRST_LOGIN, FORBIDDEN);
+        }
+
+        // 보유 옷 저장
+        Clothes clothes = clothesRequest.toEntity(user);
+        clothesRepository.save(clothes);
+
+        // 보유 옷 이미지 저장
+        List<String> imgUrls = clothesImageService.uploadClothesImages(images, clothes);
+
+        // 본인의 id 암호화하기
+        String userSid;
+        try {
+            String encodedUserId = aesUtil.encrypt(String.valueOf(user.getId()), AES_KEY);
+            userSid = Base64UrlSafeUtil.encode(encodedUserId);
+        } catch (Exception e) {
+            throw new BaseException(FAIL_TO_ENCRYPT, INTERNAL_SERVER_ERROR);
+        }
+
+        return new ClothesResponse(user, userSid, clothes, imgUrls);
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -48,7 +48,7 @@ public enum BaseResponseStatus {
     // 3. Rental (2200 ~ 2299)
     EMPTY_CLOTHES_ID(false, 2200, "보유 옷 id가 필요합니다."),
     FORBIDDEN_CREATE_RENTAL_INFO(false, 2201, "판매자만 대여 정보를 입력할 수 있습니다."),
-    TOO_MANY_IMAGES(false, 2203, "대여글 이미지는 최대 3장까지 첨부할 수 있습니다."),
+    TOO_MANY_RENTAL_IMAGES(false, 2203, "대여글 이미지는 최대 3장까지 첨부할 수 있습니다."),
     RENTAL_CHECK_EXISTS(false, 2204, "옷 상태는 한 번만 체크할 수 있습니다."),
     FORBIDDEN_CREATE_RENTAL_CHECK(false, 2205, "대여자만 옷 상태를 체크할 수 있습니다."),
     REQUEST_RENTAL_CHECK(false, 2206, "대여자가 옷 상태를 먼저 체크해야 대여할 수 있습니다."),
@@ -61,6 +61,8 @@ public enum BaseResponseStatus {
     FORBIDDEN_ENTER_CHAT_ROOM(false, 2302, "채팅방 참여자가 아닙니다."),
     REQUEST_EMPTY_MESSAGE(false, 2303, "메시지를 입력해주세요."),
 
+    // 5. Clothes (2400 ~ 2499)
+    TOO_MANY_CLOTHES_IMAGES(false, 2400, "보유 옷 이미지는 최대 3장까지 첨부할 수 있습니다."),
 
     /*
         3000 : Response 오류

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -54,6 +54,7 @@ public enum BaseResponseStatus {
     REQUEST_RENTAL_CHECK(false, 2206, "대여자가 옷 상태를 먼저 체크해야 대여할 수 있습니다."),
     FORBIDEEN_DELETE_RENTAL(false, 2207, "대여 중인 경우에는 대여글을 삭제할 수 없습니다."),
     REVIEW_EXISTS(false, 2208, "거래 후기는 한 번만 작성할 수 있습니다."),
+    FORBIDDEN_CREATE_RENTAL(false, 2209, "보유 옷을 가진 회원만 해당 대여글을 작성할 수 있습니다."),
 
     // 4. Chat (2300 ~ 2399)
     FORBIDDEN_CREATE_CHAT_ROOM(false, 2300, "대여글 작성자는 채팅방을 만들 수 없습니다."),
@@ -80,6 +81,9 @@ public enum BaseResponseStatus {
 
     // 4. Chat
     NOT_FOUND_CHAT_ROOM(false, 3300, "채팅방을 찾을 수 없습니다."),
+
+    // 5. Clothes
+    NOT_FOUNT_CLOTHES(false, 3400, "보유 옷을 찾을 수 없습니다."),
 
     /*
         4000 : Database, Server 오류

--- a/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
@@ -49,6 +49,10 @@ public class RentalController {
                 }
             }
 
+            if (images == null) {
+                images = new MultipartFile[0];
+            }
+
             // 대여글 이미지 최대 3장
             if (images.length > 3) {
                 throw new BaseException(TOO_MANY_RENTAL_IMAGES, PAYLOAD_TOO_LARGE);

--- a/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/controller/RentalController.java
@@ -51,7 +51,7 @@ public class RentalController {
 
             // 대여글 이미지 최대 3장
             if (images.length > 3) {
-                throw new BaseException(TOO_MANY_IMAGES, PAYLOAD_TOO_LARGE);
+                throw new BaseException(TOO_MANY_RENTAL_IMAGES, PAYLOAD_TOO_LARGE);
             }
 
             return new ResponseEntity<>(new BaseResponse<>(rentalService.createRental(rentalRequest, images, userDetails.user)), CREATED);
@@ -206,7 +206,7 @@ public class RentalController {
 
             // 대여글 이미지 최대 3장
             if (images.length > 3) {
-                throw new BaseException(TOO_MANY_IMAGES, PAYLOAD_TOO_LARGE);
+                throw new BaseException(TOO_MANY_RENTAL_IMAGES, PAYLOAD_TOO_LARGE);
             }
 
             return new ResponseEntity<>(new BaseResponse<>(rentalService.updateRental(rentalRequest, images, userDetails.user, rentalId)), OK);

--- a/src/main/java/com/yooyoung/clotheser/rental/domain/Rental.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/domain/Rental.java
@@ -30,8 +30,7 @@ public class Rental {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private User user;
-
-    // TODO: 필요 시 보유 옷 FK 걸기
+    
     private Long clothesId;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalRequest.java
@@ -18,9 +18,12 @@ import java.util.List;
 @Builder
 public class RentalRequest {
 
-    @Schema(title = "제목", description = "20자 이내", example = "스퀘어 블라우스", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(title = "보유 옷 id", description = "보유 옷을 선택해서 대여글 작성하는 경우 입력", example = "1")
+    private Long clothesId;
+
+    @Schema(title = "제목", description = "50자 이내", example = "스퀘어 블라우스", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "제목을 입력해주세요.")
-    @Size(max = 20, message = "제목은 20자 이내로 입력해주세요.")
+    @Size(max = 50, message = "제목은 50자 이내로 입력해주세요.")
     private String title;
 
     @Schema(title = "상세 설명", description = "500자 이내", example = "여름에 입기 너무 좋아요!\n새로운 스타일을 도전해보세요~", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -50,6 +53,7 @@ public class RentalRequest {
     public Rental toEntity(User user) {
         return Rental.builder()
                 .user(user)
+                .clothesId(clothesId)
                 .title(title)
                 .description(description)
                 .gender(gender)

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/RentalResponse.java
@@ -19,6 +19,9 @@ public class RentalResponse {
     @Schema(title = "대여글 id", example = "3")
     private Long id;
 
+    @Schema(title = "보유 옷 id", example = "1")
+    private Long clothesId;
+
     // 회원 정보
     @Schema(title = "암호화된 회원 id", example = "xfweriok12")
     private String userSid;
@@ -67,6 +70,7 @@ public class RentalResponse {
 
     public RentalResponse(User user, String userSid, Rental rental, List<String> imgUrls, List<RentalPriceDto> prices) {
         this.id = rental.getId();
+        this.clothesId = rental.getClothesId();
 
         this.userSid = userSid;
         this.profileUrl = rental.getUser().getProfileUrl();

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalImageService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalImageService.java
@@ -38,8 +38,8 @@ public class RentalImageService {
     public List<String> uploadImages(MultipartFile[] images, Rental rental) throws BaseException {
         List<String> imgUrls = new ArrayList<>();
 
-        // 대여글 이미지 없는 경우
-        if (images[0].isEmpty()) {
+        // 대여글 이미지 없는 경우 (1: Swaager, 2: Postman)
+        if (images.length == 0 || images[0].isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
## 🎯 관련 이슈
close #88 

<br>

## 📝 구현 내용
- [x] 보유 옷 관련 엔티티 생성
- [x] 보유 옷 생성 API 제작
- [x] 대여글 생성 시 보유 옷 연결
- [x] 대여글, 보유 옷 생성 API에서 이미지 없이 요청할 때 빈 값 처리 (Swagger, Postman)

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
