### PR TITLE
보유 옷 목록 조회 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/clothes/controller/ClothesController.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/controller/ClothesController.java
@@ -1,17 +1,21 @@
 package com.yooyoung.clotheser.clothes.controller;
 
 import com.yooyoung.clotheser.closet.dto.UserRentalListResponse;
+import com.yooyoung.clotheser.clothes.dto.ClothesListResponse;
 import com.yooyoung.clotheser.clothes.dto.ClothesRequest;
 import com.yooyoung.clotheser.clothes.dto.ClothesResponse;
 import com.yooyoung.clotheser.clothes.service.ClothesService;
+import com.yooyoung.clotheser.global.entity.AgeFilter;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponse;
 import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
 import com.yooyoung.clotheser.rental.service.RentalService;
 import com.yooyoung.clotheser.user.domain.CustomUserDetails;
+import com.yooyoung.clotheser.user.domain.Gender;
 import com.yooyoung.clotheser.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -140,6 +144,40 @@ public class ClothesController {
         try {
             User user = userDetails.user;
             return new ResponseEntity<>(new BaseResponse<>(clothesService.deleteClothes(clothesId, user)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
+    /* 보유 옷 목록 조회 */
+    @Operation(summary = "보유 옷 목록 조회", description = "회원의 성별, 카테고리, 스타일 유사도 기준으로 보유 옷 목록을 조회한다.")
+    @Parameters({
+            @Parameter(name = "search", description = "상품명을 기준으로 대소문자 구분 없이 검색한다.", example = "블라우스"),
+            @Parameter(name = "sort", description = "특정 기준으로 정렬한다.", example = "createdAt"),
+            @Parameter(name = "gender", description = "성별을 기준으로 필터링한다. (중복 가능)"),
+            @Parameter(name = "minHeight", description = "최소 키를 기준으로 필터링한다.", example = "158"),
+            @Parameter(name = "maxHeight", description = "최대 키를 기준으로 필터링한다.", example = "165"),
+            @Parameter(name = "age", description = "나이대를 기준으로 필터링한다. (중복 가능)"),
+            @Parameter(name = "category", description = "카테고리를 기준으로 필터링한다. (중복 가능)", example = "[\"셔츠\"]"),
+            @Parameter(name = "style", description = "스타일을 기준으로 필터링한다. (중복 가능)", example = "[\"러블리\"]")
+    })
+    @GetMapping("")
+    public ResponseEntity<BaseResponse<List<ClothesListResponse>>> getClothes(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String sort,
+            @RequestParam(required = false) List<Gender> gender,
+            @RequestParam(required = false) Integer minHeight,
+            @RequestParam(required = false) Integer maxHeight,
+            @RequestParam(required = false) List<AgeFilter> age,
+            @RequestParam(required = false) List<String> category,
+            @RequestParam(required = false) List<String> style
+    ) {
+        try {
+            User user = userDetails.user;
+            return new ResponseEntity<>(new BaseResponse<>(clothesService.getClothesList(user, search, sort, gender,
+                    minHeight, maxHeight, age, category, style)), OK);
         }
         catch (BaseException exception) {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());

--- a/src/main/java/com/yooyoung/clotheser/clothes/dto/ClothesListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/dto/ClothesListResponse.java
@@ -1,0 +1,41 @@
+package com.yooyoung.clotheser.clothes.dto;
+
+import com.yooyoung.clotheser.clothes.domain.Clothes;
+import com.yooyoung.clotheser.global.entity.Time;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class ClothesListResponse {
+
+    @Schema(title = "보유 옷 id", example = "1")
+    private Long id;
+
+    @Schema(title = "암호화된 회원 id", example = "xfweriok12")
+    private String userSid;
+
+    @Schema(title = "작성자 닉네임", example = "김눈송")
+    private String nickname;
+
+    @Schema(title = "보유 옷 썸네일 (첫 번째 사진)", example = "https://clotheser-s3-bucket.s3.ap-northeast-2.amazonaws.com/clothes/340182f1-8340-444b-bc2f-3149068a117e_%ED%8A%B8%EB%A0%8C%EC%B9%98%EC%BD%94%ED%8A%B8.png")
+    private String imgUrl;
+
+    @Schema(title = "상품명", example = "여름 나시")
+    private String name;
+
+    @Schema(title = "보유 옷 등록 시간", example = "2시간 전")
+    private String createdAt;
+
+    public ClothesListResponse(Clothes clothes, String userSid, String imgUrl) {
+        this.id = clothes.getId();
+        this.userSid = userSid;
+        this.nickname = clothes.getUser().getNickname();
+        this.imgUrl = imgUrl;
+        this.name = clothes.getName();
+        this.createdAt = Time.calculateTime(clothes.getCreatedAt());
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
@@ -1,0 +1,181 @@
+package com.yooyoung.clotheser.clothes.service;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DatePath;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yooyoung.clotheser.clothes.domain.Clothes;
+import com.yooyoung.clotheser.clothes.domain.QClothes;
+import com.yooyoung.clotheser.global.entity.AgeFilter;
+import com.yooyoung.clotheser.user.domain.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ClothesFilterService {
+
+    private final JPAQueryFactory queryFactory;
+
+    /* 보유 옷 목록 필터링 */
+    public List<Clothes> getFilteredClothesList(User user, String search, String sort, List<Gender> gender, Integer minHeight,
+                                                Integer maxHeight, List<AgeFilter> age, List<String> category, List<String> style) {
+
+        QClothes qClothes = QClothes.clothes;
+        QUser qUser = QUser.user;
+
+        // 기본적인 쿼리
+        JPAQuery<Clothes> query = queryFactory.selectFrom(qClothes)
+                .leftJoin(qClothes.user, qUser)
+                .where(qClothes.deletedAt.isNull())
+                .where(qClothes.user.ne(user));
+
+        // 검색
+        if (search != null && !search.isEmpty()) {
+            query.where(qClothes.name.containsIgnoreCase(search));
+        }
+
+        // 성별 필터링
+        if (gender != null) {
+            query.where(qClothes.gender.in(gender));
+        }
+
+        // 키 필터링 (한 쪽에만 조건 걸어도 가능)
+        if (minHeight != null && maxHeight != null) {
+            query.where(qUser.height.between(minHeight, maxHeight));
+        } else if (minHeight != null) {
+            query.where(qUser.height.goe(minHeight));
+        } else if (maxHeight != null) {
+            query.where(qUser.height.loe(maxHeight));
+        }
+
+        // 나이대 필터링
+        BooleanExpression ageCondition = ageFilterCondition(qUser, age);
+        if (ageCondition != null) {
+            query.where(ageCondition);
+        }
+
+        // 카테고리 필터링
+        if (category != null && !category.isEmpty()) {
+            query.where(qClothes.category.in(category));
+        }
+
+        // 스타일 필터링
+        if (style != null && !style.isEmpty()) {
+            query.where(qClothes.style.in(style));
+        }
+
+        // 사용자 선호 카테고리 및 스타일 조회
+        List<String> userFavCategories = getUserFavCategories(user.getId());
+        List<String> userFavStyles = getUserFavStyles(user.getId());
+
+        // 정렬
+        List<Clothes> clothesList = query.fetch();
+
+        // Comparator 생성
+        Comparator<Clothes> comparator = null;
+
+        if (sort != null && !sort.isEmpty()) {
+            if (sort.equals("createdAt")) {
+                // 최신순 정렬
+                comparator = Comparator.comparing(Clothes::getCreatedAt).reversed();
+            } else if (sort.equals("closetScore")) {
+                // 옷장 점수 높은 순 정렬
+                comparator = Comparator.comparing((Clothes c) -> c.getUser().getClosetScore()).reversed();
+            }
+        }
+
+        if (comparator != null) {
+            // 기본 정렬 후, 동일한 값일 경우 유사도 기준으로 정렬
+            comparator = comparator.thenComparing(c -> calculateSimilarity(c, userFavCategories, userFavStyles), Comparator.reverseOrder());
+        } else {
+            // 정렬 옵션이 없을 경우 유사도 기준으로 정렬
+            comparator = Comparator.comparingDouble((Clothes c) -> calculateSimilarity(c, userFavCategories, userFavStyles)).reversed();
+        }
+
+        // Comparator를 사용하여 정렬 수행
+        return clothesList.stream()
+                .sorted(comparator)
+                .collect(Collectors.toList());
+    }
+
+
+    /* 나이대 필터링 */
+    private BooleanExpression ageFilterCondition(QUser qUser, List<AgeFilter> ageFilters) {
+        if (ageFilters == null || ageFilters.isEmpty()) {
+            return null;
+        }
+
+        BooleanExpression ageCondition = null;
+        for (AgeFilter filter : ageFilters) {
+            // 필터링
+            BooleanExpression currentCondition = createAgeCondition(qUser.birthday, filter);
+            ageCondition = (ageCondition == null) ? currentCondition : ageCondition.or(currentCondition);
+        }
+
+        return ageCondition;
+    }
+
+    private BooleanExpression createAgeCondition(DatePath<LocalDate> birthday, AgeFilter filter) {
+        String baseCondition = "(YEAR(CURRENT_DATE) - YEAR({0}) - " +
+                "(CASE WHEN MONTH(CURRENT_DATE) > MONTH({0}) " +
+                "OR (MONTH(CURRENT_DATE) = MONTH({0}) " +
+                "AND DAY(CURRENT_DATE) >= DAY({0})) " +
+                "THEN 0 ELSE 1 END)) ";
+
+        return switch (filter) {
+            case TEENAGER -> Expressions.booleanTemplate(baseCondition + "<= 19", birthday);
+            case EARLY_TWENTIES -> Expressions.booleanTemplate(baseCondition + "BETWEEN 20 AND 22", birthday);
+            case MID_TWENTIES -> Expressions.booleanTemplate(baseCondition + "BETWEEN 23 AND 26", birthday);
+            case LATE_TWENTIES -> Expressions.booleanTemplate(baseCondition + "BETWEEN 27 AND 29", birthday);
+            case OTHER -> Expressions.booleanTemplate(baseCondition + ">= 30", birthday);
+        };
+    }
+
+    /* 유사도 계산 */
+    private double calculateSimilarity(Clothes clothes, List<String> userFavCategories, List<String> userFavStyles) {
+        int similarityScore = 0;
+
+        // 성별 유사도 계산
+        if (clothes.getGender() == clothes.getGender()) {
+            similarityScore += 1;
+        }
+
+        // 카테고리 유사도 계산
+        if (userFavCategories.contains(clothes.getCategory())) {
+            similarityScore += 1;
+        }
+
+        // 스타일 유사도 계산
+        if (userFavStyles.contains(clothes.getStyle())) {
+            similarityScore += 1;
+        }
+
+        return similarityScore;
+    }
+
+    /* 사용자 선호 카테고리 조회 */
+    private List<String> getUserFavCategories(Long userId) {
+        QFavClothes qFavClothes = QFavClothes.favClothes;
+        return queryFactory.select(qFavClothes.category)
+                .from(qFavClothes)
+                .where(qFavClothes.user.id.eq(userId))
+                .fetch();
+    }
+
+    /* 사용자 선호 스타일 조회 */
+    private List<String> getUserFavStyles(Long userId) {
+        QFavStyle qFavStyle = QFavStyle.favStyle;
+        return queryFactory.select(qFavStyle.style)
+                .from(qFavStyle)
+                .where(qFavStyle.user.id.eq(userId))
+                .fetch();
+    }
+
+}


### PR DESCRIPTION
## 🎯 관련 이슈
close #98 

<br>

## 📝 구현 내용
- [x] 보유 옷 목록 조회
- 기본: 성별, 카테고리, 스타일 유사도 높은 순 정렬
- 정렬: 최신순, 옷장 점수 높은 순 (동일 순위는 유사도 높은 순)
- 검색: 상품명 기준
- 필터링: 성별, 키, 연령대, 카테고리, 스타일 (대여글과 동일)

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
