### PR TITLE
신고 내역 조회 및 조치 API

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/admin/controller/AdminController.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/controller/AdminController.java
@@ -2,12 +2,14 @@ package com.yooyoung.clotheser.admin.controller;
 
 import com.yooyoung.clotheser.admin.dto.response.AdminLoginResponse;
 import com.yooyoung.clotheser.admin.dto.response.ReportListResponse;
+import com.yooyoung.clotheser.admin.dto.response.ReportResponse;
 import com.yooyoung.clotheser.admin.service.AdminService;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponse;
 import com.yooyoung.clotheser.user.dto.request.LoginRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,7 @@ public class AdminController {
 
     private final AdminService adminService;
 
+    /* 관리자 로그인 */
     @Operation(summary = "관리자 로그인", description = "관리자가 로그인을 하여 JWT를 얻는다.")
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<AdminLoginResponse>> adminLogin(@Valid @RequestBody LoginRequest loginRequest,
@@ -50,11 +53,26 @@ public class AdminController {
         }
     }
 
+
+    /* 신고 목록 조회 */
     @Operation(summary = "신고 목록 조회", description = "신고 목록을 조회한다.")
     @GetMapping("/reports")
     public ResponseEntity<BaseResponse<List<ReportListResponse>>> getReportList() {
         try {
             return new ResponseEntity<>(new BaseResponse<>(adminService.getReportList()), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
+    /* 신고 조회 */
+    @Operation(summary = "신고 조회", description = "특정 신고 내역을 조회한다.")
+    @Parameter(name = "reportId", description = "신고 id", example = "1", required = true)
+    @GetMapping("/reports/{reportId}")
+    public ResponseEntity<BaseResponse<ReportResponse>> getReport(@PathVariable("reportId") Long reportId) {
+        try {
+            return new ResponseEntity<>(new BaseResponse<>(adminService.getReport(reportId)), OK);
         }
         catch (BaseException exception) {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());

--- a/src/main/java/com/yooyoung/clotheser/admin/controller/AdminController.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.yooyoung.clotheser.admin.controller;
 
 import com.yooyoung.clotheser.admin.dto.response.AdminLoginResponse;
+import com.yooyoung.clotheser.admin.dto.response.ReportListResponse;
 import com.yooyoung.clotheser.admin.service.AdminService;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponse;
@@ -43,6 +44,17 @@ public class AdminController {
             }
 
             return new ResponseEntity<>(new BaseResponse<>(adminService.adminLogin(loginRequest)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
+    @Operation(summary = "신고 목록 조회", description = "신고 목록을 조회한다.")
+    @GetMapping("/reports")
+    public ResponseEntity<BaseResponse<List<ReportListResponse>>> getReportList() {
+        try {
+            return new ResponseEntity<>(new BaseResponse<>(adminService.getReportList()), OK);
         }
         catch (BaseException exception) {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());

--- a/src/main/java/com/yooyoung/clotheser/admin/domain/Report.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/domain/Report.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -51,5 +52,10 @@ public class Report {
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @LastModifiedDate
+    @Column(insertable = false) // 생성 시 null
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/com/yooyoung/clotheser/admin/domain/Report.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/domain/Report.java
@@ -58,4 +58,9 @@ public class Report {
     @Column(insertable = false) // 생성 시 null
     private LocalDateTime updatedAt;
 
+    public Report updateAction(ReportAction action) {
+        this.action = action;
+        this.state = ReportState.ACTIONED;
+        return this;
+    }
 }

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/request/ReportActionRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/request/ReportActionRequest.java
@@ -1,0 +1,19 @@
+package com.yooyoung.clotheser.admin.dto.request;
+
+import com.yooyoung.clotheser.admin.domain.ReportAction;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class ReportActionRequest {
+
+    @Schema(title = "신고 조치", example = "RESTRICTED", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "신고 조치를 입력해주세요.")
+    private ReportAction action;
+
+}

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportListResponse.java
@@ -1,0 +1,65 @@
+package com.yooyoung.clotheser.admin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.yooyoung.clotheser.admin.domain.Report;
+import com.yooyoung.clotheser.admin.domain.ReportAction;
+import com.yooyoung.clotheser.admin.domain.ReportState;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class ReportListResponse {
+
+    @Schema(title = "신고 id", example = "1")
+    private Long id;
+
+    @Schema(title = "신고 대상 닉네임", example = "진도리")
+    private String reporteeNickname;
+
+    @Schema(title = "신고 사유", example = "광고")
+    private String reason;
+
+    @Schema(title = "신고 내용", example = "광고성 게시물을 올렸어요. 확인 부탁드립니다.")
+    private String content;
+
+    @Schema(title = "신고 대상 옷장 점수", example = "10")
+    private double closetScore;
+
+    @Schema(title = "처리 상태", example = "PENDING")
+    private ReportState state;
+
+    @Schema(title = "신고 조치 내역", example = "RESTRICTED")
+    private ReportAction action;
+
+    @Schema(title = "신고한 시간", example = "2024년 06월 20일 17:55:40")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+
+    public ReportListResponse(Report report) {
+        this.id = report.getId();
+        this.reporteeNickname = report.getReportee().getNickname();
+        this.reason = report.getReason();
+        this.content = report.getContent();
+
+        double closetScore = report.getReportee().getClosetScore();
+        if (closetScore == (int) closetScore) {
+            this.closetScore = Double.parseDouble(String.format("%d", (int) closetScore));
+        }
+        else {
+            BigDecimal bd = new BigDecimal(closetScore).setScale(1, RoundingMode.DOWN);
+            this.closetScore = bd.doubleValue();
+        }
+
+        this.state = report.getState();
+        this.createdAt = report.getCreatedAt();
+    }
+
+}

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.yooyoung.clotheser.admin.domain.Report;
 import com.yooyoung.clotheser.admin.domain.ReportAction;
 import com.yooyoung.clotheser.admin.domain.ReportState;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -16,13 +15,22 @@ import java.time.LocalDateTime;
 
 @Data
 @Setter(AccessLevel.NONE)
-public class ReportListResponse {
+public class ReportResponse {
 
     @Schema(title = "신고 id", example = "1")
     private Long id;
 
     @Schema(title = "신고 대상 닉네임", example = "진도리")
     private String reporteeNickname;
+
+    @Schema(title = "신고 대상 이메일", example = "hello1@gmail.com")
+    private String reporteeEmail;
+
+    @Schema(title = "작성자 닉네임", example = "lucia")
+    private String reporterNickname;
+
+    @Schema(title = "작성자 이메일", example = "lucia0725@naver.com")
+    private String reporterEmail;
 
     @Schema(title = "신고 사유", example = "광고")
     private String reason;
@@ -43,9 +51,13 @@ public class ReportListResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
-    public ReportListResponse(Report report) {
+    public ReportResponse(Report report) {
         this.id = report.getId();
         this.reporteeNickname = report.getReportee().getNickname();
+        this.reporteeEmail = report.getReportee().getEmail();
+        this.reporterNickname = report.getReporter().getNickname();
+        this.reporterEmail = report.getReporter().getEmail();
+
         this.reason = report.getReason();
         this.content = report.getContent();
 

--- a/src/main/java/com/yooyoung/clotheser/admin/repository/ReportRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/repository/ReportRepository.java
@@ -4,6 +4,11 @@ import com.yooyoung.clotheser.admin.domain.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    List<Report> findAllByOrderByIdDesc();
+
 }

--- a/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
@@ -3,6 +3,7 @@ package com.yooyoung.clotheser.admin.service;
 import com.yooyoung.clotheser.admin.domain.Report;
 import com.yooyoung.clotheser.admin.dto.response.AdminLoginResponse;
 import com.yooyoung.clotheser.admin.dto.response.ReportListResponse;
+import com.yooyoung.clotheser.admin.dto.response.ReportResponse;
 import com.yooyoung.clotheser.admin.repository.ReportRepository;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.jwt.JwtProvider;
@@ -36,7 +37,7 @@ public class AdminService {
     private final JwtProvider jwtProvider;
     private final ReportRepository reportRepository;
 
-    // 로그인
+    /* 관리자 로그인 */
     public AdminLoginResponse adminLogin(LoginRequest loginRequest) throws BaseException {
 
         // 이메일로 회원 존재 확인
@@ -81,6 +82,7 @@ public class AdminService {
         return new AdminLoginResponse(user, tokenResponse);
     }
 
+    /* 신고 목록 조회 */
     public List<ReportListResponse> getReportList() throws BaseException {
 
         List<Report> reports = reportRepository.findAllByOrderByIdDesc();
@@ -90,5 +92,14 @@ public class AdminService {
         }
 
         return responses;
+    }
+
+    /* 신고 조회 */
+    public ReportResponse getReport(Long reportId) throws BaseException {
+
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_REPORT, NOT_FOUND));
+
+        return new ReportResponse(report);
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
@@ -1,11 +1,15 @@
 package com.yooyoung.clotheser.admin.service;
 
 import com.yooyoung.clotheser.admin.domain.Report;
+import com.yooyoung.clotheser.admin.domain.ReportAction;
+import com.yooyoung.clotheser.admin.domain.ReportState;
+import com.yooyoung.clotheser.admin.dto.request.ReportActionRequest;
 import com.yooyoung.clotheser.admin.dto.response.AdminLoginResponse;
 import com.yooyoung.clotheser.admin.dto.response.ReportListResponse;
 import com.yooyoung.clotheser.admin.dto.response.ReportResponse;
 import com.yooyoung.clotheser.admin.repository.ReportRepository;
 import com.yooyoung.clotheser.global.entity.BaseException;
+import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
 import com.yooyoung.clotheser.global.jwt.JwtProvider;
 import com.yooyoung.clotheser.user.domain.RefreshToken;
 import com.yooyoung.clotheser.user.domain.Role;
@@ -101,5 +105,49 @@ public class AdminService {
                 .orElseThrow(() -> new BaseException(NOT_FOUND_REPORT, NOT_FOUND));
 
         return new ReportResponse(report);
+    }
+
+    /* 신고 처리 */
+    public BaseResponseStatus actionReport(Long reportId, ReportActionRequest reportActionRequest) throws BaseException {
+
+        // 신고 불러오기
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_REPORT, NOT_FOUND));
+
+        // 신고 조치는 한 번만 가능
+        if (report.getState() == ReportState.ACTIONED) {
+            throw new BaseException(REPORT_ACTION_EXISTS, CONFLICT);
+        }
+
+        // 조치별 이후 로직
+        ReportAction action = reportActionRequest.getAction();
+        switch (action) {
+            // 1. 이용 제한
+            case RESTRICTED -> {
+                // 회원 이용 제한 설정
+                // -> 로그인 시도 시 "서비스 이용이 제한되었습니다."
+                // -> 대여글, 보유 옷 숨김 처리 (목록 응답값에서 제외됨)
+                // -> 채팅방 목록, 채팅방 조회에서 isRestricted = true
+                User reportee = report.getReportee();
+                reportee = reportee.updateIsRestricted();
+                userRepository.save(reportee);
+            }
+
+            // 2. 옷장 점수 차감
+            case DOCKED -> {
+                User reportee = report.getReportee();
+                reportee = reportee.updateClosetScore(-2);
+                userRepository.save(reportee);
+            }
+
+            // 3. 무시
+            case IGNORED -> {}
+        }
+
+        // 신고 조치 내역 변경
+        report = report.updateAction(action);
+        reportRepository.save(report);
+
+        return SUCCESS;
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
@@ -1,6 +1,9 @@
 package com.yooyoung.clotheser.admin.service;
 
+import com.yooyoung.clotheser.admin.domain.Report;
 import com.yooyoung.clotheser.admin.dto.response.AdminLoginResponse;
+import com.yooyoung.clotheser.admin.dto.response.ReportListResponse;
+import com.yooyoung.clotheser.admin.repository.ReportRepository;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.jwt.JwtProvider;
 import com.yooyoung.clotheser.user.domain.RefreshToken;
@@ -15,6 +18,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.yooyoung.clotheser.global.entity.BaseResponseStatus.*;
 import static org.springframework.http.HttpStatus.*;
 
@@ -28,6 +34,7 @@ public class AdminService {
 
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final ReportRepository reportRepository;
 
     // 로그인
     public AdminLoginResponse adminLogin(LoginRequest loginRequest) throws BaseException {
@@ -74,4 +81,14 @@ public class AdminService {
         return new AdminLoginResponse(user, tokenResponse);
     }
 
+    public List<ReportListResponse> getReportList() throws BaseException {
+
+        List<Report> reports = reportRepository.findAllByOrderByIdDesc();
+        List<ReportListResponse> responses = new ArrayList<>();
+        for (Report report : reports) {
+            responses.add(new ReportListResponse(report));
+        }
+
+        return responses;
+    }
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/controller/RentalChatController.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/controller/RentalChatController.java
@@ -59,7 +59,7 @@ public class RentalChatController {
     @Parameter(name = "roomId", description = "채팅방 id", example = "1", required = true)
     @GetMapping("/{roomId}")
     public ResponseEntity<BaseResponse<RentalChatRoomResponse>> getRentalChatRoom(@PathVariable("roomId") Long roomId,
-                                                                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
+                                                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
         try {
             return new ResponseEntity<>(new BaseResponse<>(rentalChatService.getRentalChatRoom(roomId, userDetails.user)), OK);
         }

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
@@ -25,6 +25,8 @@ public class RentalChatRoomListResponse {
     private String nickname;
     @Schema(title = "상대방 프로필 사진 URL", example = "https://clotheser-s3-bucket.s3.ap-northeast-2.amazonaws.com/profiles/noonsong.png")
     private String profileImgUrl;
+    @Schema(title = "상대방 이용 제한 여부", example = "false")
+    private Boolean isRestricted;
 
     // 대여글 정보
     @Schema(title = "대여글 제목", example = "스퀘어 블라우스")
@@ -49,6 +51,7 @@ public class RentalChatRoomListResponse {
         this.userSid = userSid;
         this.nickname = opponent.getNickname();
         this.profileImgUrl = opponent.getProfileUrl();
+        this.isRestricted = opponent.getIsRestricted();
 
         this.title = chatRoom.getRental().getTitle();
         this.rentalImgUrl = rentalImgUrl;

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomResponse.java
@@ -4,6 +4,7 @@ import com.yooyoung.clotheser.chat.domain.ChatRoom;
 import com.yooyoung.clotheser.rental.domain.Rental;
 import com.yooyoung.clotheser.rental.domain.RentalState;
 
+import com.yooyoung.clotheser.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -28,6 +29,8 @@ public class RentalChatRoomResponse {
     private String opponentSid;
     @Schema(title = "상대방 닉네임", example = "황숙명")
     private String opponentNickname;
+    @Schema(title = "상대방 이용 제한 여부", example = "false")
+    private Boolean isRestricted;
 
     // 대여글 정보
     @Schema(title = "대여글 id", example = "1")
@@ -54,14 +57,15 @@ public class RentalChatRoomResponse {
     private List<ChatMessageResponse> messages;
 
     /* 채팅방 생성 시 쓰는 생성자 */
-    public RentalChatRoomResponse(ChatRoom chatRoom, String opponentSid, String opponentNickname,
+    public RentalChatRoomResponse(ChatRoom chatRoom, String opponentSid, User opponent,
                                   Rental rental, String rentalImgUrl, Integer minPrice) {
         this.id = chatRoom.getId();
         this.buyerNickname = chatRoom.getBuyer().getNickname();
         this.lenderNickname = chatRoom.getLender().getNickname();
 
         this.opponentSid = opponentSid;
-        this.opponentNickname = opponentNickname;
+        this.opponentNickname = opponent.getNickname();
+        this.isRestricted = opponent.getIsRestricted();
 
         this.rentalId = rental.getId();
         this.rentalImgUrl = rentalImgUrl;
@@ -71,14 +75,15 @@ public class RentalChatRoomResponse {
     }
 
     /* 채팅방 조회 시 쓰는 생성자 */
-    public RentalChatRoomResponse(ChatRoom chatRoom, String opponentSid, String opponentNickname, List<ChatMessageResponse> messages,
+    public RentalChatRoomResponse(ChatRoom chatRoom, String opponentSid, User opponent, List<ChatMessageResponse> messages,
                                   String rentalImgUrl, Integer minPrice, Boolean isChecked, RentalState rentalState, Boolean isReviewed) {
         this.id = chatRoom.getId();
         this.buyerNickname = chatRoom.getBuyer().getNickname();
         this.lenderNickname = chatRoom.getLender().getNickname();
 
         this.opponentSid = opponentSid;
-        this.opponentNickname = opponentNickname;
+        this.opponentNickname = opponent.getNickname();
+        this.isRestricted = opponent.getIsRestricted();
 
         this.rentalId = chatRoom.getRental().getId();
         this.rentalImgUrl = rentalImgUrl;

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomListResponse.java
@@ -22,6 +22,8 @@ public class UserChatRoomListResponse {
     private String nickname;
     @Schema(title = "상대방 프로필 사진 URL", example = "https://clotheser-s3-bucket.s3.ap-northeast-2.amazonaws.com/profiles/noonsong.png")
     private String profileImgUrl;
+    @Schema(title = "상대방 이용 제한 여부", example = "false")
+    private Boolean isRestricted;
 
     @Schema(title = "최근 메시지", example = "안녕하세요~")
     private String recentMessage;
@@ -33,6 +35,7 @@ public class UserChatRoomListResponse {
         this.userSid = userSid;
         this.nickname = opponent.getNickname();
         this.profileImgUrl = opponent.getProfileUrl();
+        this.isRestricted = opponent.getIsRestricted();
         this.recentMessage = recentMessage;
         this.recentMessageTime = Time.calculateTime(chatRoom.getUpdatedAt());
     }

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomResponse.java
@@ -1,5 +1,6 @@
 package com.yooyoung.clotheser.chat.dto;
 
+import com.yooyoung.clotheser.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -20,6 +21,9 @@ public class UserChatRoomResponse {
     @Schema(title = "상대방 닉네임", example = "황숙명")
     private String opponentNickname;
 
+    @Schema(title = "상대방 이용 제한 여부", example = "false")
+    private Boolean isRestricted;
+
     @Schema(description = "채팅 메시지 목록", type = "array")
     private List<ChatMessageResponse> messages;
 
@@ -31,10 +35,11 @@ public class UserChatRoomResponse {
     }
 
     /* 유저 채팅방 조회 시 사용 */
-    public UserChatRoomResponse(Long id, String opponentSid, String opponentNickname, List<ChatMessageResponse> messages) {
+    public UserChatRoomResponse(Long id, String opponentSid, User opponent, List<ChatMessageResponse> messages) {
         this.id = id;
         this.opponentSid = opponentSid;
-        this.opponentNickname = opponentNickname;
+        this.opponentNickname = opponent.getNickname();
+        this.isRestricted = opponent.getIsRestricted();
         this.messages = messages;
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/service/RentalChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/RentalChatService.java
@@ -100,7 +100,7 @@ public class RentalChatService {
         // 가격 정보 중에 제일 싼 가격 불러오기
         Integer minPrice = rentalPriceRepository.findMinPrice(rental).orElse(null);
 
-        return new RentalChatRoomResponse(chatRoom, lenderSid, chatRoom.getLender().getNickname(), rental, rentalImgUrl, minPrice);
+        return new RentalChatRoomResponse(chatRoom, lenderSid, chatRoom.getLender(), rental, rentalImgUrl, minPrice);
 
     }
 
@@ -228,7 +228,7 @@ public class RentalChatService {
             isReviewed = false;
         }
 
-        return new RentalChatRoomResponse(chatRoom, opponentSid, opponent.getNickname(), chatMessageResponseList,
+        return new RentalChatRoomResponse(chatRoom, opponentSid, opponent, chatMessageResponseList,
                 rentalImgUrl, minPrice, isChecked, rentalState, isReviewed);
 
     }

--- a/src/main/java/com/yooyoung/clotheser/chat/service/UserChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/UserChatService.java
@@ -168,7 +168,7 @@ public class UserChatService {
             throw new BaseException(FAIL_TO_ENCRYPT, INTERNAL_SERVER_ERROR);
         }
 
-        return new UserChatRoomResponse(chatRoom.getId(), opponentSid, opponent.getNickname(), chatMessageResponseList);
+        return new UserChatRoomResponse(chatRoom.getId(), opponentSid, opponent, chatMessageResponseList);
     }
 
 }

--- a/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
@@ -34,6 +34,7 @@ public class ClothesFilterService {
         JPAQuery<Clothes> query = queryFactory.selectFrom(qClothes)
                 .leftJoin(qClothes.user, qUser)
                 .where(qClothes.deletedAt.isNull())
+                .where(qUser.isRestricted.isFalse())    // 이용 제한 회원 제외
                 .where(qClothes.user.ne(user));
 
         // 검색

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -39,11 +39,15 @@ public enum BaseResponseStatus {
 
     // 로그인
     LOGIN_MISMATCH(false, 2130, "이메일과 비밀번호가 일치하지 않습니다."),
+    LOGIN_RESTRICTED(false, 2131, "서비스 이용이 제한되었습니다."),
 
     // 인증
     INVALID_AUTH_CODE(false, 2140, "유효하지 않은 인증 번호입니다."),
     FAILED_TO_CHECK_EMAIL(false, 2141, "이메일 인증에 실패하였습니다."),
     FAILED_TO_CHECK_PHONE(false, 2142, "휴대폰 인증에 실패하였습니다."),
+
+    // 신고
+    REPORT_ACTION_EXISTS(false, 2150, "이미 처리된 신고입니다."),
 
     // 3. Rental (2200 ~ 2299)
     EMPTY_CLOTHES_ID(false, 2200, "보유 옷 id가 필요합니다."),

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -94,6 +94,9 @@ public enum BaseResponseStatus {
     // 5. Clothes
     NOT_FOUND_CLOTHES(false, 3400, "보유 옷을 찾을 수 없습니다."),
 
+    // 6. Report
+    NOT_FOUND_REPORT(false, 3500, "해당 신고를 찾을 수 없습니다."),
+
     /*
         4000 : Database, Server 오류
     */

--- a/src/main/java/com/yooyoung/clotheser/rental/dto/request/RentalRequest.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/dto/request/RentalRequest.java
@@ -40,7 +40,7 @@ public class RentalRequest {
     private String style;
 
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-    @Valid
+    @Valid      // 리스트의 각 요소 유효성 검사 목적
     @NotEmpty(message = "가격 정보를 입력해주세요.")
     private List<RentalPriceDto> prices;
 

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalFilterService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalFilterService.java
@@ -38,6 +38,7 @@ public class RentalFilterService {
         JPAQuery<Rental> query = queryFactory.selectFrom(qRental)
                 .leftJoin(qRental.user, qUser)
                 .where(qRental.deletedAt.isNull())
+                .where(qUser.isRestricted.isFalse())    // 이용 제한 회원 제외
                 .where(distanceWithin(qUser, longitude, latitude));
 
         // 검색

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -80,6 +80,11 @@ public class User {
     @Builder.Default
     private Role isAdmin = Role.USER;
 
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    @ColumnDefault("false")
+    @Builder.Default
+    private Boolean isRestricted = false;
+
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -182,12 +187,21 @@ public class User {
     }
 
     // 옷장 점수 수정
-    public void updateClosetScore(double difference) {
+    public User updateClosetScore(double difference) {
         this.closetScore += difference;
+        this.updatedAt = LocalDateTime.now();
+
         if (this.closetScore > 20)
             this.closetScore = 20;
         else if (this.closetScore < 0)
             this.closetScore = 0;
+
+        return this;
     }
 
+    // 이용 제한 설정
+    public User updateIsRestricted() {
+        this.isRestricted = true;
+        return this;
+    }
 }

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -101,6 +101,11 @@ public class UserService {
             throw new BaseException(LOGIN_MISMATCH, BAD_REQUEST);
         }
 
+        // 이용 제한된 회원 확인
+        if (user.getIsRestricted()) {
+            throw new BaseException(LOGIN_RESTRICTED, FORBIDDEN);
+        }
+
         // 토큰 생성
         TokenResponse tokenResponse = jwtProvider.createToken(user.getId(), user.getIsAdmin().name());
 


### PR DESCRIPTION
## 🎯 관련 이슈
#107 

<br>

## 📝 구현 내용
- [x] 신고 목록 조회
- [x] 신고 조회
- [x] 신고 조치
  - [x] 신고 당한 유저가 로그인 시도 시 “서비스 이용이 제한되었습니다.” 문구와 함께 접근 제한
  - [x] 신고 당한 유저가 작성한 대여글 및 보유 옷은 모두 숨김 처리
  - [x] 채팅방 목록, 채팅방 조회 시 isRestricted = true (“신고 당한 유저입니다” 표시)
<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
