### PR TITLE
유예 상태 기능 구현 (관리자 측면)

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/admin/controller/AdminController.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/controller/AdminController.java
@@ -6,6 +6,7 @@ import com.yooyoung.clotheser.admin.dto.response.ReportListResponse;
 import com.yooyoung.clotheser.admin.dto.response.ReportResponse;
 import com.yooyoung.clotheser.admin.dto.response.UserListResponse;
 import com.yooyoung.clotheser.admin.service.AdminService;
+import com.yooyoung.clotheser.chat.dto.RentalChatRoomListResponse;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponse;
 import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
@@ -111,6 +112,19 @@ public class AdminController {
     public ResponseEntity<BaseResponse<List<UserListResponse>>> getUserList(@RequestParam(required = false) String search) {
         try {
             return new ResponseEntity<>(new BaseResponse<>(adminService.getUserList(search)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
+    /* 거래 중인 채팅방 목록 조회 */
+    @Operation(summary = "거래 중인 채팅방 목록 조회", description = "신고 당한 회원의 거래 중인 채팅방 목록을 조회한다.")
+    @Parameter(name = "userSid", description = "암호화된 회원 id", example = "M0h1QXdzUlVzNkRwckdUeUEvbjVQZz09", required = true)
+    @GetMapping("/chats/{userSid}/rented-rooms")
+    public ResponseEntity<BaseResponse<List<RentalChatRoomListResponse>>> getRentedChatRoomList(@PathVariable String userSid) {
+        try {
+            return new ResponseEntity<>(new BaseResponse<>(adminService.getRentedChatRoomList(userSid)), OK);
         }
         catch (BaseException exception) {
             return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());

--- a/src/main/java/com/yooyoung/clotheser/admin/domain/ReportAction.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/domain/ReportAction.java
@@ -1,6 +1,7 @@
 package com.yooyoung.clotheser.admin.domain;
 
 public enum ReportAction {
+    SUSPENDED,
     RESTRICTED,     // 이용 제한
     DOCKED,         // 옷장 점수 차감
     IGNORED         // 무시

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportListResponse.java
@@ -33,6 +33,9 @@ public class ReportListResponse {
     @Schema(title = "신고 대상 옷장 점수", example = "10")
     private double closetScore;
 
+    @Schema(title = "거래중 여부", example = "false")
+    private Boolean isRented;
+
     @Schema(title = "처리 상태", example = "PENDING")
     private ReportState state;
 
@@ -43,7 +46,7 @@ public class ReportListResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
-    public ReportListResponse(Report report) {
+    public ReportListResponse(Report report, boolean isRented) {
         this.id = report.getId();
         this.reporteeNickname = report.getReportee().getNickname();
         this.reason = report.getReason();
@@ -58,6 +61,7 @@ public class ReportListResponse {
             this.closetScore = bd.doubleValue();
         }
 
+        this.isRented = isRented;
         this.state = report.getState();
         this.action = report.getAction();
         this.createdAt = report.getCreatedAt();

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportListResponse.java
@@ -21,6 +21,9 @@ public class ReportListResponse {
     @Schema(title = "신고 id", example = "1")
     private Long id;
 
+    @Schema(title = "암호화된 회원 id", example = "M0h1QXdzUlVzNkRwckdUeUEvbjVQZz09")
+    private String userSid;
+
     @Schema(title = "신고 대상 닉네임", example = "진도리")
     private String reporteeNickname;
 
@@ -46,8 +49,9 @@ public class ReportListResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
-    public ReportListResponse(Report report, boolean isRented) {
+    public ReportListResponse(Report report, String userSid, boolean isRented) {
         this.id = report.getId();
+        this.userSid = userSid;
         this.reporteeNickname = report.getReportee().getNickname();
         this.reason = report.getReason();
         this.content = report.getContent();

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportResponse.java
@@ -41,6 +41,9 @@ public class ReportResponse {
     @Schema(title = "신고 대상 옷장 점수", example = "10")
     private double closetScore;
 
+    @Schema(title = "거래중 여부", example = "false")
+    private Boolean isRented;
+
     @Schema(title = "처리 상태", example = "PENDING")
     private ReportState state;
 
@@ -51,7 +54,7 @@ public class ReportResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
-    public ReportResponse(Report report) {
+    public ReportResponse(Report report, boolean isRented) {
         this.id = report.getId();
         this.reporteeNickname = report.getReportee().getNickname();
         this.reporteeEmail = report.getReportee().getEmail();
@@ -70,6 +73,7 @@ public class ReportResponse {
             this.closetScore = bd.doubleValue();
         }
 
+        this.isRented = isRented;
         this.state = report.getState();
         this.action = report.getAction();
         this.createdAt = report.getCreatedAt();

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/response/ReportResponse.java
@@ -20,6 +20,9 @@ public class ReportResponse {
     @Schema(title = "신고 id", example = "1")
     private Long id;
 
+    @Schema(title = "암호화된 회원 id", example = "M0h1QXdzUlVzNkRwckdUeUEvbjVQZz09")
+    private String userSid;
+
     @Schema(title = "신고 대상 닉네임", example = "진도리")
     private String reporteeNickname;
 
@@ -54,8 +57,9 @@ public class ReportResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
-    public ReportResponse(Report report, boolean isRented) {
+    public ReportResponse(Report report, String userSid , boolean isRented) {
         this.id = report.getId();
+        this.userSid = userSid;
         this.reporteeNickname = report.getReportee().getNickname();
         this.reporteeEmail = report.getReportee().getEmail();
         this.reporterNickname = report.getReporter().getNickname();

--- a/src/main/java/com/yooyoung/clotheser/admin/dto/response/UserListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/dto/response/UserListResponse.java
@@ -39,6 +39,9 @@ public class UserListResponse {
     @Schema(title = "거래 건수", example = "4")
     private int rentalCount;
 
+    @Schema(title = "유예 여부", example = "false")
+    private Boolean isSuspended;
+
     @Schema(title = "이용 제한 여부", example = "false")
     private Boolean isRestricted;
 
@@ -64,6 +67,7 @@ public class UserListResponse {
         this.positiveKeywordCount = positiveKeywordCount;
         this.negativeKeywordCount = negativeKeywordCount;
         this.rentalCount = rentalCount;
+        this.isSuspended = user.getIsSuspended();
         this.isRestricted = user.getIsRestricted();
         this.createdAt = user.getCreatedAt();
     }

--- a/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
@@ -12,6 +12,7 @@ import com.yooyoung.clotheser.admin.repository.ReportRepository;
 import com.yooyoung.clotheser.global.entity.BaseException;
 import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
 import com.yooyoung.clotheser.global.jwt.JwtProvider;
+import com.yooyoung.clotheser.rental.domain.RentalState;
 import com.yooyoung.clotheser.rental.repository.RentalInfoRepository;
 import com.yooyoung.clotheser.review.domain.Review;
 import com.yooyoung.clotheser.review.repository.ReviewKeywordRepository;
@@ -100,7 +101,14 @@ public class AdminService {
         List<Report> reports = reportRepository.findAllByOrderByIdDesc();
         List<ReportListResponse> responses = new ArrayList<>();
         for (Report report : reports) {
-            responses.add(new ReportListResponse(report));
+
+            Long reporteeId = report.getReportee().getId();
+            // 거래중 여부 확인
+            boolean isRented = rentalInfoRepository.existsByBuyerIdAndStateOrLenderIdAndState(
+                    reporteeId, RentalState.RENTED, reporteeId, RentalState.RENTED
+            );
+
+            responses.add(new ReportListResponse(report, isRented));
         }
 
         return responses;
@@ -112,7 +120,13 @@ public class AdminService {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_REPORT, NOT_FOUND));
 
-        return new ReportResponse(report);
+        Long reporteeId = report.getReportee().getId();
+        // 거래중 여부 확인
+        boolean isRented = rentalInfoRepository.existsByBuyerIdAndStateOrLenderIdAndState(
+                reporteeId, RentalState.RENTED, reporteeId, RentalState.RENTED
+        );
+
+        return new ReportResponse(report, isRented);
     }
 
     /* 신고 처리 */

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
@@ -44,7 +44,7 @@ public class RentalChatRoomListResponse {
     @Schema(title = "마지막으로 메시지 보낸 시간", example = "3시간 전")
     private String recentMessageTime;
 
-    public RentalChatRoomListResponse(ChatRoom chatRoom, String userSid, RentalInfo rentalInfo,
+    public RentalChatRoomListResponse(ChatRoom chatRoom, String userSid, RentalState rentalState,
                                       String recentMessage, String rentalImgUrl, User opponent) {
         this.id = chatRoom.getId();
 
@@ -57,9 +57,7 @@ public class RentalChatRoomListResponse {
         this.rentalImgUrl = rentalImgUrl;
         this.isDeleted = chatRoom.getRental().getDeletedAt() != null;
 
-        if (rentalInfo != null) {
-            this.rentalState = rentalInfo.getState();
-        }
+        this.rentalState = rentalState;
 
         this.recentMessage = recentMessage;
         this.recentMessageTime = Time.calculateTime(chatRoom.getUpdatedAt());

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
@@ -2,7 +2,6 @@ package com.yooyoung.clotheser.chat.dto;
 
 import com.yooyoung.clotheser.chat.domain.ChatRoom;
 import com.yooyoung.clotheser.global.entity.Time;
-import com.yooyoung.clotheser.rental.domain.RentalInfo;
 import com.yooyoung.clotheser.rental.domain.RentalState;
 import com.yooyoung.clotheser.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/yooyoung/clotheser/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/repository/ChatRoomRepository.java
@@ -33,4 +33,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "c.rental is null and c.updatedAt is not null order by c.updatedAt desc")
     List<ChatRoom> findUserChatRoomsByUserId(Long userId);
 
+    // 대여 중인 대여글 채팅방 목록 조회
+    @Query("select c from ChatRoom c " +
+            "join RentalInfo ri on c.rental = ri.rental and c.buyer = ri.buyer and c.lender = ri.lender " +
+            "where (c.buyer.id = :userId or c.lender.id = :userId) and " +
+            "c.rental is not null and c.updatedAt is not null and " +
+            "ri.state = com.yooyoung.clotheser.rental.domain.RentalState.RENTED order by c.updatedAt desc")
+    List<ChatRoom> findRentedChatRoomsByUserId(Long userId);
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/service/RentalChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/RentalChatService.java
@@ -17,6 +17,7 @@ import com.yooyoung.clotheser.global.util.Base64UrlSafeUtil;
 import com.yooyoung.clotheser.rental.domain.*;
 import com.yooyoung.clotheser.rental.repository.*;
 import com.yooyoung.clotheser.review.repository.ReviewRepository;
+import com.yooyoung.clotheser.user.domain.Role;
 import com.yooyoung.clotheser.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
@@ -169,8 +170,8 @@ public class RentalChatService {
         ChatRoom chatRoom = chatRoomRepository.findOneByIdAndRentalIdNotNull(roomId)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_RENTAL_CHAT_ROOM, NOT_FOUND));
 
-        // 채팅방 참여자인지 확인
-        if (!chatRoom.getBuyer().getId().equals(user.getId()) && !chatRoom.getLender().getId().equals(user.getId()) ) {
+        // 채팅방 참여자인지 확인 (관리자는 가능)
+        if (user.getIsAdmin() == Role.USER && checkChatRoomUser(chatRoom, user.getId())) {
             throw new BaseException(FORBIDDEN_ENTER_CHAT_ROOM, FORBIDDEN);
         }
 
@@ -250,7 +251,7 @@ public class RentalChatService {
                 .orElseThrow(() -> new BaseException(NOT_FOUND_CHAT_ROOM, NOT_FOUND));
 
         // 채팅방 참여자인지 확인
-        if (!chatRoom.getBuyer().getId().equals(user.getId()) && !chatRoom.getLender().getId().equals(user.getId()) ) {
+        if (checkChatRoomUser(chatRoom, user.getId())) {
             throw new BaseException(FORBIDDEN_ENTER_CHAT_ROOM, FORBIDDEN);
         }
 
@@ -259,6 +260,11 @@ public class RentalChatService {
         chatRoomRepository.save(chatRoom.updateRecentMessageTime());
         // 채팅 메시지 저장
         return new ChatMessageResponse(chatMessageRepository.save(chatMessage));
+    }
+
+    // 채팅방 참여자가 아니면 true
+    public boolean checkChatRoomUser(ChatRoom chatRoom, Long userId) {
+        return !chatRoom.getBuyer().getId().equals(userId) && !chatRoom.getLender().getId().equals(userId);
     }
 
 }

--- a/src/main/java/com/yooyoung/clotheser/chat/service/RentalChatService.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/service/RentalChatService.java
@@ -139,6 +139,10 @@ public class RentalChatService {
                     chatRoom.getBuyer().getId(),
                     chatRoom.getLender().getId(),
                     chatRoom.getRental().getId()).orElse(null);
+            RentalState rentalState = null;
+            if (rentalInfo != null) {
+                rentalState = rentalInfo.getState();
+            }
 
             // 채팅방의 최근 메시지 불러오기
             Optional<ChatMessage> optionalMessage = chatMessageRepository.findFirstByRoomIdOrderByCreatedAtDesc(chatRoom.getId());
@@ -148,7 +152,7 @@ public class RentalChatService {
             Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(chatRoom.getRental().getId());
             String imgUrl = optionalImg.map(RentalImg::getImgUrl).orElse(null);
 
-            chatRoomResponseList.add(new RentalChatRoomListResponse(chatRoom, opponentSid, rentalInfo, recentMessage, imgUrl, opponent));
+            chatRoomResponseList.add(new RentalChatRoomListResponse(chatRoom, opponentSid, rentalState, recentMessage, imgUrl, opponent));
         }
         return chatRoomResponseList;
     }

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -39,7 +39,7 @@ public enum BaseResponseStatus {
 
     // 로그인
     LOGIN_MISMATCH(false, 2130, "이메일과 비밀번호가 일치하지 않습니다."),
-    LOGIN_RESTRICTED(false, 2131, "서비스 이용이 제한되었습니다."),
+    USE_RESTRICTED(false, 2131, "서비스 이용이 제한되었습니다."),
 
     // 인증
     INVALID_AUTH_CODE(false, 2140, "유효하지 않은 인증 번호입니다."),

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -48,6 +48,7 @@ public enum BaseResponseStatus {
 
     // 신고
     REPORT_ACTION_EXISTS(false, 2150, "이미 처리된 신고입니다."),
+    REPORT_USER_RENTAL_EXISTS(false, 2151, "거래 중인 경우 이용 제한을 할 수 없습니다. 유예 상태에서 거래 완료를 유도하세요."),
 
     // 3. Rental (2200 ~ 2299)
     EMPTY_CLOTHES_ID(false, 2200, "보유 옷 id가 필요합니다."),

--- a/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/repository/RentalInfoRepository.java
@@ -33,4 +33,9 @@ public interface RentalInfoRepository extends JpaRepository<RentalInfo, Long> {
     // 거래 건수
     int countByBuyerIdOrLenderId(Long buyer_id, Long lender_id);
 
+    // 회원이 대여 중인지 확인
+    boolean existsByBuyerIdAndStateOrLenderIdAndState(Long buyerId, RentalState buyerState,
+                                                      Long lenderId, RentalState lenderState);
+
+
 }

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -204,6 +204,12 @@ public class User {
         return this;
     }
 
+    // 유예 설정
+    public User updateIsSuspended() {
+        this.isSuspended = true;
+        return this;
+    }
+
     // 이용 제한 설정
     public User updateIsRestricted() {
         this.isRestricted = true;

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -83,6 +83,11 @@ public class User {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     @ColumnDefault("false")
     @Builder.Default
+    private Boolean isSuspended = false;
+
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    @ColumnDefault("false")
+    @Builder.Default
     private Boolean isRestricted = false;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -103,7 +103,7 @@ public class UserService {
 
         // 이용 제한된 회원 확인
         if (user.getIsRestricted()) {
-            throw new BaseException(LOGIN_RESTRICTED, FORBIDDEN);
+            throw new BaseException(USE_RESTRICTED, FORBIDDEN);
         }
 
         // 토큰 생성


### PR DESCRIPTION
## 🎯 관련 이슈
#112

<br>

## 📝 구현 내용
- [x] 신고 목록 및 상세 조회 시 거래중 여부 추가
- [x] 회원 목록 조회 시 유예 여부 추가
- [x] 신고 조치에 SUSPENDED 추가
- [x] 거래 중인 채팅방 목록 조회 API + 신고 내역에 userSid 추가
- [x] 대여글 채팅방 조회 시 관리자 가능하게 권한 설정

<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
