### PR TITLE
회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
+++ b/src/main/java/com/yooyoung/clotheser/admin/service/AdminService.java
@@ -197,8 +197,6 @@ public class AdminService {
                 // -> 로그인 시도 시 "서비스 이용이 제한되었습니다."
                 // -> 대여글, 보유 옷 숨김 처리 (목록 응답값에서 제외됨)
                 // -> 대여글, 채팅방 목록, 채팅방 조회에서 isRestricted = true
-                // TODO: 대여글 isRestricted 추가
-
                 boolean isRented = rentalInfoRepository.existsByBuyerIdAndStateOrLenderIdAndState(
                         report.getReportee().getId(), RentalState.RENTED, report.getReportee().getId(), RentalState.RENTED
                 );

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomListResponse.java
@@ -28,6 +28,8 @@ public class RentalChatRoomListResponse {
     private Boolean isSuspended;
     @Schema(title = "상대방 이용 제한 여부", example = "false")
     private Boolean isRestricted;
+    @Schema(title = "상대방 탈퇴 여부", example = "false")
+    private Boolean isWithdrawn;
 
     // 대여글 정보
     @Schema(title = "대여글 제목", example = "스퀘어 블라우스")
@@ -54,6 +56,7 @@ public class RentalChatRoomListResponse {
         this.profileImgUrl = opponent.getProfileUrl();
         this.isSuspended = opponent.getIsSuspended();
         this.isRestricted = opponent.getIsRestricted();
+        this.isWithdrawn = opponent.getDeletedAt() != null;
 
         this.title = chatRoom.getRental().getTitle();
         this.rentalImgUrl = rentalImgUrl;

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/RentalChatRoomResponse.java
@@ -33,6 +33,8 @@ public class RentalChatRoomResponse {
     private Boolean isSuspended;
     @Schema(title = "상대방 이용 제한 여부", example = "false")
     private Boolean isRestricted;
+    @Schema(title = "상대방 탈퇴 여부", example = "false")
+    private Boolean isWithdrawn;
 
     // 대여글 정보
     @Schema(title = "대여글 id", example = "1")
@@ -71,6 +73,7 @@ public class RentalChatRoomResponse {
         this.opponentNickname = opponent.getNickname();
         this.isSuspended = opponent.getIsSuspended();
         this.isRestricted = opponent.getIsRestricted();
+        this.isWithdrawn = opponent.getDeletedAt() != null;
 
         this.rentalId = rental.getId();
         this.rentalImgUrl = rentalImgUrl;
@@ -91,6 +94,7 @@ public class RentalChatRoomResponse {
         this.opponentNickname = opponent.getNickname();
         this.isSuspended = opponent.getIsSuspended();
         this.isRestricted = opponent.getIsRestricted();
+        this.isWithdrawn = opponent.getDeletedAt() != null;
 
         this.rentalId = chatRoom.getRental().getId();
         this.rentalImgUrl = rentalImgUrl;

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomListResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomListResponse.java
@@ -26,6 +26,8 @@ public class UserChatRoomListResponse {
     private Boolean isSuspended;
     @Schema(title = "상대방 이용 제한 여부", example = "false")
     private Boolean isRestricted;
+    @Schema(title = "상대방 탈퇴 여부", example = "false")
+    private Boolean isWithdrawn;
 
     @Schema(title = "최근 메시지", example = "안녕하세요~")
     private String recentMessage;
@@ -39,6 +41,7 @@ public class UserChatRoomListResponse {
         this.profileImgUrl = opponent.getProfileUrl();
         this.isSuspended = opponent.getIsSuspended();
         this.isRestricted = opponent.getIsRestricted();
+        this.isWithdrawn = opponent.getDeletedAt() != null;
         this.recentMessage = recentMessage;
         this.recentMessageTime = Time.calculateTime(chatRoom.getUpdatedAt());
     }

--- a/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/chat/dto/UserChatRoomResponse.java
@@ -27,6 +27,9 @@ public class UserChatRoomResponse {
     @Schema(title = "상대방 이용 제한 여부", example = "false")
     private Boolean isRestricted;
 
+    @Schema(title = "상대방 탈퇴 여부", example = "false")
+    private Boolean isWithdrawn;
+
     @Schema(description = "채팅 메시지 목록", type = "array")
     private List<ChatMessageResponse> messages;
 
@@ -37,6 +40,7 @@ public class UserChatRoomResponse {
         this.opponentNickname = opponentNickname;
         this.isSuspended = false;
         this.isRestricted = false;
+        this.isWithdrawn = false;
     }
 
     /* 유저 채팅방 조회 시 사용 */
@@ -46,6 +50,7 @@ public class UserChatRoomResponse {
         this.opponentNickname = opponent.getNickname();
         this.isSuspended = opponent.getIsSuspended();
         this.isRestricted = opponent.getIsRestricted();
+        this.isWithdrawn = opponent.getDeletedAt() != null;
         this.messages = messages;
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/closet/dto/RentalHistoryResponse.java
+++ b/src/main/java/com/yooyoung/clotheser/closet/dto/RentalHistoryResponse.java
@@ -3,6 +3,7 @@ package com.yooyoung.clotheser.closet.dto;
 import com.yooyoung.clotheser.rental.domain.Rental;
 import com.yooyoung.clotheser.rental.domain.RentalInfo;
 import com.yooyoung.clotheser.rental.domain.RentalState;
+import com.yooyoung.clotheser.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -29,6 +30,9 @@ public class RentalHistoryResponse {
     @Schema(title = "상대방 닉네임", example = "김눈송")
     private String nickname;
 
+    @Schema(title = "상대방 탈퇴 여부", example = "false")
+    private Boolean isWithdrawn;
+
     @Schema(title = "제목", example = "여름 나시")
     private String title;
 
@@ -51,12 +55,13 @@ public class RentalHistoryResponse {
     private LocalDate endDate;
 
     public RentalHistoryResponse(Rental rental, Long roomId, String userSid, String imgUrl,
-                                 String nickname, int minPrice, int minDays, RentalInfo rentalInfo) {
+                                 User user, int minPrice, int minDays, RentalInfo rentalInfo) {
         this.id = rental.getId();
         this.roomId = roomId;
         this.userSid = userSid;
         this.imgUrl = imgUrl;
-        this.nickname = nickname;
+        this.nickname = user.getNickname();
+        this.isWithdrawn = user.getDeletedAt() != null;
         this.title = rental.getTitle();
         this.minPrice = minPrice;
         this.minDays = minDays;

--- a/src/main/java/com/yooyoung/clotheser/closet/service/ClosetService.java
+++ b/src/main/java/com/yooyoung/clotheser/closet/service/ClosetService.java
@@ -223,8 +223,8 @@ public class ClosetService {
                 throw new BaseException(FAIL_TO_ENCRYPT, INTERNAL_SERVER_ERROR);
             }
 
-            // 대여자 닉네임 구하기
-            String nickname = rentalInfo.getBuyer().getNickname();
+            // 대여자 구하기
+            User buyer = rentalInfo.getBuyer();
 
             // 첫 번째 이미지 URL 불러오기
             Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(rental.getId());
@@ -240,7 +240,7 @@ public class ClosetService {
             }
 
             // RentalHistoryResponse 객체 생성 및 리스트에 추가
-            RentalHistoryResponse response = new RentalHistoryResponse(rental, roomId, userSid, imgUrl, nickname, minPrice, minDays, rentalInfo);
+            RentalHistoryResponse response = new RentalHistoryResponse(rental, roomId, userSid, imgUrl, buyer, minPrice, minDays, rentalInfo);
             responses.add(response);
         }
 
@@ -282,8 +282,8 @@ public class ClosetService {
                 throw new BaseException(FAIL_TO_ENCRYPT, INTERNAL_SERVER_ERROR);
             }
 
-            // 작성자 닉네임 구하기
-            String nickname = rental.getUser().getNickname();
+            // 작성자 구하기
+            User writer = rental.getUser();
 
             // 첫 번째 이미지 URL 불러오기
             Optional<RentalImg> optionalImg = rentalImgRepository.findFirstByRentalId(rental.getId());
@@ -299,7 +299,7 @@ public class ClosetService {
             }
 
             // RentalHistoryResponse 객체 생성 및 리스트에 추가
-            RentalHistoryResponse response = new RentalHistoryResponse(rental, roomId, userSid, imgUrl, nickname, minPrice, minDays, rentalInfo);
+            RentalHistoryResponse response = new RentalHistoryResponse(rental, roomId, userSid, imgUrl, writer, minPrice, minDays, rentalInfo);
             responses.add(response);
         }
 

--- a/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
@@ -35,8 +35,8 @@ public class ClothesFilterService {
                 .leftJoin(qClothes.user, qUser)
                 .where(qClothes.deletedAt.isNull())
                 .where(qClothes.isPublic.isTrue())
-                .where(qUser.isSuspended.isFalse())     // 유예된 회원 제외
-                .where(qUser.isRestricted.isFalse())    // 이용 제한 회원 제외
+                .where(qUser.isSuspended.isFalse())
+                .where(qUser.isRestricted.isFalse())
                 .where(qClothes.user.ne(user));
 
         // 검색

--- a/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
+++ b/src/main/java/com/yooyoung/clotheser/clothes/service/ClothesFilterService.java
@@ -37,6 +37,7 @@ public class ClothesFilterService {
                 .where(qClothes.isPublic.isTrue())
                 .where(qUser.isSuspended.isFalse())
                 .where(qUser.isRestricted.isFalse())
+                .where(qUser.deletedAt.isNull())
                 .where(qClothes.user.ne(user));
 
         // 검색

--- a/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
+++ b/src/main/java/com/yooyoung/clotheser/global/entity/BaseResponseStatus.java
@@ -49,6 +49,9 @@ public enum BaseResponseStatus {
     // 신고
     REPORT_USER_RENTAL_EXISTS(false, 2150, "거래 중인 경우 이용 제한을 할 수 없습니다. 유예 상태에서 거래 완료를 유도하세요."),
 
+    // 회원 탈퇴
+    WITHDRAW_USER_RENTAL_EXISTS(false, 2160, "거래 중인 경우 탈퇴할 수 없습니다."),
+
     // 3. Rental (2200 ~ 2299)
     EMPTY_CLOTHES_ID(false, 2200, "보유 옷 id가 필요합니다."),
     FORBIDDEN_CREATE_RENTAL_INFO(false, 2201, "판매자만 대여 정보를 입력할 수 있습니다."),

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalFilterService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalFilterService.java
@@ -40,6 +40,7 @@ public class RentalFilterService {
                 .where(qRental.deletedAt.isNull())
                 .where(qUser.isSuspended.isFalse())
                 .where(qUser.isRestricted.isFalse())
+                .where(qUser.deletedAt.isNull())
                 .where(distanceWithin(qUser, longitude, latitude));
 
         // 검색

--- a/src/main/java/com/yooyoung/clotheser/rental/service/RentalFilterService.java
+++ b/src/main/java/com/yooyoung/clotheser/rental/service/RentalFilterService.java
@@ -38,8 +38,8 @@ public class RentalFilterService {
         JPAQuery<Rental> query = queryFactory.selectFrom(qRental)
                 .leftJoin(qRental.user, qUser)
                 .where(qRental.deletedAt.isNull())
-                .where(qUser.isSuspended.isFalse())     // 유예된 회원 제외
-                .where(qUser.isRestricted.isFalse())    // 이용 제한 회원 제외
+                .where(qUser.isSuspended.isFalse())
+                .where(qUser.isRestricted.isFalse())
                 .where(distanceWithin(qUser, longitude, latitude));
 
         // 검색

--- a/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
+++ b/src/main/java/com/yooyoung/clotheser/user/controller/UserController.java
@@ -359,4 +359,16 @@ public class UserController {
         }
     }
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 한다.")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<BaseResponse<BaseResponseStatus>> withdrawUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            User user = userDetails.user;
+            return new ResponseEntity<>(new BaseResponse<>(userService.withdrawUser(user)), OK);
+        }
+        catch (BaseException exception) {
+            return new ResponseEntity<>(new BaseResponse<>(exception.getStatus()), exception.getHttpStatus());
+        }
+    }
+
 }

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -90,6 +90,11 @@ public class User {
     @Builder.Default
     private Boolean isRestricted = false;
 
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    @ColumnDefault("false")
+    @Builder.Default
+    private Boolean isWithdrawn = false;
+
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -213,6 +218,13 @@ public class User {
     // 이용 제한 설정
     public User updateIsRestricted() {
         this.isRestricted = true;
+        return this;
+    }
+
+    // 회원 탈퇴
+    public User updateIsWithdrawn() {
+        this.isWithdrawn = true;
+        this.updatedAt = LocalDateTime.now();
         return this;
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/user/domain/User.java
+++ b/src/main/java/com/yooyoung/clotheser/user/domain/User.java
@@ -90,11 +90,6 @@ public class User {
     @Builder.Default
     private Boolean isRestricted = false;
 
-    @Column(nullable = false, columnDefinition = "TINYINT(1)")
-    @ColumnDefault("false")
-    @Builder.Default
-    private Boolean isWithdrawn = false;
-
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -222,9 +217,8 @@ public class User {
     }
 
     // 회원 탈퇴
-    public User updateIsWithdrawn() {
-        this.isWithdrawn = true;
-        this.updatedAt = LocalDateTime.now();
+    public User delete() {
+        this.deletedAt = LocalDateTime.now();
         return this;
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -9,6 +9,8 @@ import com.yooyoung.clotheser.global.entity.BaseResponseStatus;
 import com.yooyoung.clotheser.global.jwt.JwtProvider;
 import com.yooyoung.clotheser.global.util.AESUtil;
 import com.yooyoung.clotheser.global.util.Base64UrlSafeUtil;
+import com.yooyoung.clotheser.rental.domain.RentalState;
+import com.yooyoung.clotheser.rental.repository.RentalInfoRepository;
 import com.yooyoung.clotheser.user.domain.*;
 import com.yooyoung.clotheser.user.dto.request.*;
 import com.yooyoung.clotheser.user.dto.response.*;
@@ -53,6 +55,8 @@ public class UserService {
     private final FavClothesRepository favClothesRepository;
     private final FavStyleRepository favStyleRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+
+    private final RentalInfoRepository rentalInfoRepository;
     private final ReportRepository reportRepository;
 
     private final PasswordEncoder passwordEncoder;
@@ -460,5 +464,32 @@ public class UserService {
 
         return SUCCESS;
 
+    }
+
+    /* 회원 탈퇴 */
+    public BaseResponseStatus withdrawUser(User user) throws BaseException {
+
+        // 최초 로그인이 아닌지 확인
+        if (user.getIsFirstLogin()) {
+            throw new BaseException(REQUEST_FIRST_LOGIN, FORBIDDEN);
+        }
+
+        // 유예된 회원 확인
+        if (user.getIsSuspended()) {
+            throw new BaseException(USE_RESTRICTED, FORBIDDEN);
+        }
+
+        // 거래 중인지 확인
+        boolean isRented = rentalInfoRepository.existsByBuyerIdAndStateOrLenderIdAndState(
+                user.getId(), RentalState.RENTED, user.getId(), RentalState.RENTED
+        );
+        if (isRented) {
+            throw new BaseException(WITHDRAW_USER_RENTAL_EXISTS, FORBIDDEN);
+        }
+
+        user = user.updateIsWithdrawn();
+        userRepository.save(user);
+
+        return SUCCESS;
     }
 }

--- a/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
+++ b/src/main/java/com/yooyoung/clotheser/user/service/UserService.java
@@ -487,7 +487,7 @@ public class UserService {
             throw new BaseException(WITHDRAW_USER_RENTAL_EXISTS, FORBIDDEN);
         }
 
-        user = user.updateIsWithdrawn();
+        user = user.delete();
         userRepository.save(user);
 
         return SUCCESS;


### PR DESCRIPTION
## 🎯 관련 이슈
close #111 

<br>

## 📝 구현 내용
- [x] 회원 탈퇴 API
- [x] 탈퇴 후처리
  - 대여글: 목록 숨김 처리 (상세 조회는 채팅방에서만 이동할 수 있으므로 따로 처리 X)
  - 보유 옷: 목록 숨김 처리
  - 채팅(대여글 & 유저): 목록, 상세 조회에서 isWithdrawn 추가
  - 대여 내역: 목록에서 isWithdrawn 추가
  - 공유 내역: 목록에서 isWithdrawn 추가
<br>

<!--
## 💬 리뷰 요구사항

<br>

## 💡 참고자료

-->
